### PR TITLE
Add UseCase for load newer messages

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/LoadNewerMessagesImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/LoadNewerMessagesImpl.kt
@@ -1,0 +1,33 @@
+package io.getstream.chat.android.livedata.usecase
+
+import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.livedata.ChatDomainImpl
+import io.getstream.chat.android.livedata.utils.Call2
+import io.getstream.chat.android.livedata.utils.CallImpl2
+import io.getstream.chat.android.livedata.utils.validateCid
+
+interface LoadNewerMessages {
+    /**
+     * Loads newer messages for the channel
+     *
+     * @param cid: the full channel id IE messaging:123
+     * @param messageLimit: how many new messages to load
+     *
+     * @return A call object with Channel as the return type
+     */
+    operator fun invoke(cid: String, messageLimit: Int): Call2<Channel>
+}
+
+class LoadNewerMessagesImpl(var domainImpl: ChatDomainImpl) : LoadNewerMessages {
+    override operator fun invoke(cid: String, messageLimit: Int): Call2<Channel> {
+        validateCid(cid)
+        val channelRepo = domainImpl.channel(cid)
+        val runnable = suspend {
+            channelRepo.loadNewerMessages(messageLimit)
+        }
+        return CallImpl2<Channel>(
+            runnable,
+            channelRepo.scope
+        )
+    }
+}

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/UseCaseHelper.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/UseCaseHelper.kt
@@ -41,6 +41,12 @@ data class UseCaseHelper(var chatDomainImpl: ChatDomainImpl) {
      * Loads older messages for the given channel
      */
     var loadOlderMessages: LoadOlderMessages = LoadOlderMessagesImpl(chatDomainImpl)
+
+    /**
+     * Loads newer messages for the given channel
+     */
+    var loadNewerMessages: LoadNewerMessages = LoadNewerMessagesImpl(chatDomainImpl)
+
     /**
      * Load more channels for the given query.
      */

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/LoadNewerMessagesImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/LoadNewerMessagesImplTest.kt
@@ -1,0 +1,30 @@
+package io.getstream.chat.android.livedata.usecase
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.livedata.BaseConnectedIntegrationTest
+import io.getstream.chat.android.livedata.utils.getOrAwaitValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LoadNewerMessagesImplTest : BaseConnectedIntegrationTest() {
+
+    @Test
+    fun watchChannelUseCase() = runBlocking(Dispatchers.IO) {
+        // use case style syntax
+        val message1 = data.createMessage()
+        var channelState = chatDomain.useCases.watchChannel(data.channel1.cid, 0).execute().data()
+        val result = chatDomain.useCases.loadNewerMessages(data.channel1.cid, 10).execute()
+        assertSuccess(result as Result<Any>)
+        var messages = channelState.messages.getOrAwaitValue()
+        Truth.assertThat(messages.size).isGreaterThan(0)
+        var result2 = chatDomain.useCases.sendMessage(message1).execute()
+        assertSuccess(result2 as Result<Any>)
+        messages = channelState.messages.getOrAwaitValue()
+        Truth.assertThat(messages.last()).isEqualTo(message1)
+    }
+}


### PR DESCRIPTION
I've added UseCase for load newer messages as it implemented for load older messages. I need it for the ability to start to chat not only from the end of the list but from any position in the MessageListView. 