### PR TITLE
Bug / NotificationMarkReadEvent crash 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/livedata/build.gradle
+++ b/livedata/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'jacoco-android'
+apply plugin: 'maven-publish'
 
 //https://github.com/arturdm/jacoco-android-gradle-plugin
 
@@ -33,7 +33,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
-        versionName "0.6.4"
+        versionName "0.6.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
@@ -124,7 +124,23 @@ dependencies {
     androidTestImplementation "org.mockito:mockito-core:3.2.4"
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     androidTestImplementation 'org.amshove.kluent:kluent:1.61'
-
-
 }
 
+afterEvaluate {
+    // Creates a Maven publication which can be used to test livedata artifact locally.
+    // By default the publication is stored into ~/.m2 directory.
+    // 1. To release a local publication run `./gradlew publishToMavenLocal`
+    // 2. To use it add mavenLocal() into target project's repositories list.
+    publishing {
+        publications {
+            release(MavenPublication) {
+                // Applies the component for the release build variant
+                from components.release
+                // Custom attributes of the publication
+                groupId = project.group
+                artifactId = 'stream-chat-android-livedata'
+                version = '0.6.5-SNAPSHOT'
+            }
+        }
+    }
+}

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -791,8 +791,14 @@ class ChannelControllerImpl(
             is TypingStartEvent -> {
                 setTyping(event.user?.id!!, event)
             }
-            is MessageReadEvent, is NotificationMarkReadEvent -> {
+            is MessageReadEvent -> {
                 val read = ChannelUserRead(event.user!!, event.createdAt!!)
+                updateRead(read)
+            }
+            is NotificationMarkReadEvent -> {
+                val user = domainImpl.currentUser
+                val date = event.createdAt!!
+                val read = ChannelUserRead(user, date)
                 updateRead(read)
             }
         }


### PR DESCRIPTION
### Reason of crash:
Handling NotificationMarkReadEvent was causing a crash because `event.user` value was being sent null.

### Solution: 
Using the current user which was set to the ChatDomain instead of relying on event's data. 