### PR TITLE
Bugfix/cas 161 cid mutability causes crashes

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -25,6 +25,8 @@ import io.getstream.chat.android.client.utils.observable.Subscription
 import io.getstream.chat.android.livedata.controller.ChannelControllerImpl
 import io.getstream.chat.android.livedata.controller.QueryChannelsControllerImpl
 import io.getstream.chat.android.livedata.entity.*
+import io.getstream.chat.android.livedata.extensions.isPermanent
+import io.getstream.chat.android.livedata.extensions.users
 import io.getstream.chat.android.livedata.repository.RepositoryHelper
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
 import io.getstream.chat.android.livedata.request.QueryChannelPaginationRequest

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -7,6 +7,9 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.entity.ChannelEntity
 import io.getstream.chat.android.livedata.entity.MessageEntity
 import io.getstream.chat.android.livedata.entity.UserEntity
+import io.getstream.chat.android.livedata.extensions.getCid
+import io.getstream.chat.android.livedata.extensions.isChannelEvent
+import io.getstream.chat.android.livedata.extensions.users
 import kotlinx.coroutines.*
 
 class EventHandlerImpl(var domainImpl: io.getstream.chat.android.livedata.ChatDomainImpl, var runAsync: Boolean = true) {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -13,13 +13,14 @@ import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.ChannelData
 import io.getstream.chat.android.livedata.ChatDomainImpl
-import io.getstream.chat.android.livedata.addReaction
+import io.getstream.chat.android.livedata.extensions.addReaction
 import io.getstream.chat.android.livedata.entity.ChannelConfigEntity
 import io.getstream.chat.android.livedata.entity.ChannelEntityPair
 import io.getstream.chat.android.livedata.entity.MessageEntity
 import io.getstream.chat.android.livedata.entity.ReactionEntity
-import io.getstream.chat.android.livedata.isPermanent
-import io.getstream.chat.android.livedata.removeReaction
+import io.getstream.chat.android.livedata.extensions.getCid
+import io.getstream.chat.android.livedata.extensions.isPermanent
+import io.getstream.chat.android.livedata.extensions.removeReaction
 import io.getstream.chat.android.livedata.request.QueryChannelPaginationRequest
 import io.getstream.chat.android.livedata.utils.ChannelUnreadCountLiveData
 import io.getstream.chat.android.livedata.utils.computeUnreadCount

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -399,7 +399,7 @@ class ChannelControllerImpl(
         // we insert early to ensure we don't lose messages
         domainImpl.repos.messages.insertMessage(message)
 
-        val channelStateEntity = domainImpl.repos.channels.select(message.cid)
+        val channelStateEntity = domainImpl.repos.channels.select(message.getCid())
         channelStateEntity?.let {
             // update channel lastMessage at and lastMessageAt
             it.addMessage(messageEntity)

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -17,7 +17,7 @@ import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.livedata.ChatDomainImpl
 import io.getstream.chat.android.livedata.entity.ChannelConfigEntity
 import io.getstream.chat.android.livedata.entity.QueryChannelsEntity
-import io.getstream.chat.android.livedata.isChannelEvent
+import io.getstream.chat.android.livedata.extensions.isChannelEvent
 import io.getstream.chat.android.livedata.request.QueryChannelsPaginationRequest
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.*

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/MessageEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/MessageEntity.kt
@@ -7,6 +7,7 @@ import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.SyncStatus
+import io.getstream.chat.android.livedata.extensions.getCid
 import java.util.*
 
 /**

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/MessageEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/MessageEntity.kt
@@ -110,7 +110,7 @@ data class MessageEntity(@PrimaryKey var id: String, var cid: String, var userId
     }
 
     /** create a messageEntity from a message object */
-    constructor(m: Message) : this(m.id, m.cid, m.user.id) {
+    constructor(m: Message) : this(m.id, m.getCid(), m.user.id) {
         text = m.text
         attachments = m.attachments
         syncStatus = m.syncStatus ?: SyncStatus.COMPLETED

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
@@ -1,4 +1,4 @@
-package io.getstream.chat.android.livedata
+package io.getstream.chat.android.livedata.extensions
 
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.errors.ChatNetworkError

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
@@ -28,16 +28,13 @@ fun ChatEvent.getCid(): String? {
 /**
  * cid is sometimes devent as message.cid other times as message.channel.cid
  */
-fun Message.getCid(): String? {
-
-    var cid = this.cid
-
-    if (cid.isNullOrEmpty()) {
-        cid = this.channel?.cid
+fun Message.getCid(): String =
+    if (this.cid.isEmpty()) {
+        this.channel.cid
+    } else {
+        this.cid
     }
 
-    return cid
-}
 
 fun Message.users(): List<User> {
     val users = mutableListOf<User>()

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
@@ -7,7 +7,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.dao.ChannelDao
 import io.getstream.chat.android.livedata.entity.ChannelEntity
-import io.getstream.chat.android.livedata.isPermanent
+import io.getstream.chat.android.livedata.extensions.isPermanent
 
 class ChannelRepository(var channelDao: ChannelDao, var cacheSize: Int = 100, var currentUser: User, var client: ChatClient) {
     // the channel cache is simple, just keeps the last 100 users in memory

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/repository/MessageRepository.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/repository/MessageRepository.kt
@@ -8,7 +8,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.dao.MessageDao
 import io.getstream.chat.android.livedata.entity.MessageEntity
-import io.getstream.chat.android.livedata.isPermanent
+import io.getstream.chat.android.livedata.extensions.isPermanent
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
 import java.security.InvalidParameterException
 import java.util.*

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/repository/ReactionRepository.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/repository/ReactionRepository.kt
@@ -6,7 +6,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.dao.ReactionDao
 import io.getstream.chat.android.livedata.entity.ReactionEntity
-import io.getstream.chat.android.livedata.isPermanent
+import io.getstream.chat.android.livedata.extensions.isPermanent
 import java.security.InvalidParameterException
 
 /**

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/DeleteMessageImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/DeleteMessageImpl.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.usecase
 
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.ChatDomainImpl
+import io.getstream.chat.android.livedata.extensions.getCid
 import io.getstream.chat.android.livedata.utils.Call2
 import io.getstream.chat.android.livedata.utils.CallImpl2
 import io.getstream.chat.android.livedata.utils.validateCid
@@ -18,10 +19,7 @@ interface DeleteMessage {
 
 class DeleteMessageImpl(var domainImpl: ChatDomainImpl) : DeleteMessage {
     override operator fun invoke(message: Message): Call2<Message> {
-        var cid = message.cid
-        if (cid.isEmpty()) {
-            cid = message.channel.cid
-        }
+        val cid = message.getCid()
         validateCid(cid)
 
         val channelRepo = domainImpl.channel(cid)

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/EditMessageImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/EditMessageImpl.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.usecase
 
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.ChatDomainImpl
+import io.getstream.chat.android.livedata.extensions.getCid
 import io.getstream.chat.android.livedata.utils.Call2
 import io.getstream.chat.android.livedata.utils.CallImpl2
 import io.getstream.chat.android.livedata.utils.validateCid
@@ -19,10 +20,7 @@ interface EditMessage {
 
 class EditMessageImpl(var domainImpl: ChatDomainImpl) : EditMessage {
     override operator fun invoke(message: Message): Call2<Message> {
-        var cid = message.cid
-        if (cid.isEmpty()) {
-            cid = message.channel.cid
-        }
+        val cid = message.getCid()
         validateCid(cid)
 
         val channelRepo = domainImpl.channel(cid)

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageImpl.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.usecase
 
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.ChatDomainImpl
+import io.getstream.chat.android.livedata.extensions.getCid
 import io.getstream.chat.android.livedata.utils.Call2
 import io.getstream.chat.android.livedata.utils.CallImpl2
 import io.getstream.chat.android.livedata.utils.validateCid
@@ -19,10 +20,7 @@ interface SendMessage {
 
 class SendMessageImpl(var domainImpl: ChatDomainImpl) : SendMessage {
     override operator fun invoke(message: Message): Call2<Message> {
-        var cid = message.cid
-        if (cid.isEmpty()) {
-            cid = message.channel.cid
-        }
+        val cid = message.getCid()
         validateCid(cid)
 
         val channelRepo = domainImpl.channel(cid)
@@ -30,6 +28,7 @@ class SendMessageImpl(var domainImpl: ChatDomainImpl) : SendMessage {
         val runnable = suspend {
             channelRepo.sendMessage(message)
         }
+
         return CallImpl2<Message>(
             runnable,
             channelRepo.scope

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/ChatErrorTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/ChatErrorTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
 import io.getstream.chat.android.client.errors.ChatNetworkError
 import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.livedata.extensions.isPermanent
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTest.kt
@@ -6,6 +6,7 @@ import io.getstream.chat.android.client.api.models.Pagination
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.BaseDomainTest
+import io.getstream.chat.android.livedata.extensions.getCid
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
 import io.getstream.chat.android.livedata.utils.calendar
 import kotlinx.coroutines.Dispatchers
@@ -91,12 +92,12 @@ class MessageRepositoryTest : BaseDomainTest() {
         // this should select the first message
         var pagination = AnyChannelPaginationRequest(1)
         pagination.setFilter(Pagination.GREATER_THAN, message2.id)
-        var messages = repo.selectMessagesForChannel(data.message1.cid, pagination)
+        var messages = repo.selectMessagesForChannel(data.message1.getCid(), pagination)
         Truth.assertThat(messages.size).isEqualTo(1)
         Truth.assertThat(messages.first().id).isEqualTo(message1.id)
         // this should select the third message
         pagination.setFilter(Pagination.LESS_THAN, message2.id)
-        messages = repo.selectMessagesForChannel(data.message1.cid, pagination)
+        messages = repo.selectMessagesForChannel(data.message1.getCid(), pagination)
         Truth.assertThat(messages.size).isEqualTo(1)
         Truth.assertThat(messages.first().id).isEqualTo(message3.id)
 
@@ -105,12 +106,12 @@ class MessageRepositoryTest : BaseDomainTest() {
         // filter on 2 and older
         pagination.setFilter(Pagination.LESS_THAN_OR_EQUAL, message2.id)
         // should return message 2 and message 3, with message 3 (the oldest message as the first element)
-        messages = repo.selectMessagesForChannel(data.message1.cid, pagination)
+        messages = repo.selectMessagesForChannel(data.message1.getCid(), pagination)
         Truth.assertThat(messages.size).isEqualTo(2)
         Truth.assertThat(messages.first().id).isEqualTo(message3.id)
         // request 2 and newer, message 2 (the oldest) should be first
         pagination.setFilter(Pagination.GREATER_THAN_OR_EQUAL, message2.id)
-        messages = repo.selectMessagesForChannel(data.message1.cid, pagination)
+        messages = repo.selectMessagesForChannel(data.message1.getCid(), pagination)
         Truth.assertThat(messages.size).isEqualTo(2)
         Truth.assertThat(messages.first().id).isEqualTo(message2.id)
     }

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/EditMessageImplUseCaseTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/EditMessageImplUseCaseTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class EditMessageImplUseCase : BaseConnectedIntegrationTest() {
+class EditMessageImplUseCaseTest : BaseConnectedIntegrationTest() {
 
     @Test
     @Ignore("Flaky test. The list of messages into the livedata has some messages with a `createdAt` date in the future and break our test logic")


### PR DESCRIPTION
Access the CID of a message, ALWAYS with Channel as a backup.

We should have inmutability for CID in general, and this is the first step to unify the access to its value.