### PR TITLE
Local QuerySort

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.3.61'
+        kotlin_version = '1.3.72'
         jacocoVersion = '0.1.4'
         junitVersion = '4.12'
         jupiter_version = '5.5.1'

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         jacocoVersion = '0.1.4'
         junitVersion = '4.12'
         jupiter_version = '5.5.1'
+        mannodermausVersion = '1.5.1.0'
     }
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
@@ -18,6 +19,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:$mannodermausVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"

--- a/livedata/build.gradle
+++ b/livedata/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'jacoco-android'
 apply plugin: 'maven-publish'
+apply plugin: 'de.mannodermaus.android-junit5'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 //https://github.com/arturdm/jacoco-android-gradle-plugin
@@ -83,6 +84,7 @@ dependencies {
 
     def room_version = "2.2.5"
     def work_version = "2.3.4"
+    def jupiter_version = '5.6.1'
 
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
@@ -95,6 +97,7 @@ dependencies {
     // Kotlin + coroutines
     implementation "androidx.work:work-runtime-ktx:$work_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation "androidx.test:core:1.2.0"
@@ -117,6 +120,9 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.4'
     testImplementation "androidx.work:work-testing:$work_version"
     testImplementation 'junit:junit:4.13'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$jupiter_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$jupiter_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$jupiter_version"
 
     androidTestImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
@@ -19,7 +19,7 @@ import io.getstream.chat.android.livedata.entity.*
         ChannelConfigEntity::class,
         SyncStateEntity::class
     ],
-    version = 16,
+    version = 17,
     exportSchema = false
 )
 

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -24,6 +24,7 @@ import io.getstream.chat.android.client.utils.observable.Subscription
 import io.getstream.chat.android.livedata.controller.ChannelControllerImpl
 import io.getstream.chat.android.livedata.controller.QueryChannelsControllerImpl
 import io.getstream.chat.android.livedata.entity.*
+import io.getstream.chat.android.livedata.extensions.applyPagination
 import io.getstream.chat.android.livedata.extensions.isPermanent
 import io.getstream.chat.android.livedata.extensions.users
 import io.getstream.chat.android.livedata.repository.RepositoryHelper
@@ -609,7 +610,7 @@ class ChatDomainImpl private constructor(
         return selectAndEnrichChannels(channelIds, pagination.toAnyChannelPaginationRequest())
     }
 
-    internal suspend fun selectAndEnrichChannels(
+    private suspend fun selectAndEnrichChannels(
         channelIds: List<String>,
         pagination: AnyChannelPaginationRequest
     ): List<ChannelEntityPair> {
@@ -660,7 +661,7 @@ class ChatDomainImpl private constructor(
 
             channelPairs.add(channelPair)
         }
-        return channelPairs.toList()
+        return channelPairs.toList().applyPagination(pagination)
     }
 
     override fun clean() {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -512,7 +512,7 @@ class ChatDomainImpl private constructor(
         val updatedChannelIds = mutableSetOf<String>()
         val queriesToRetry = activeQueryMapImpl.values.toList().filter { it.recoveryNeeded || recoveryNeeded }.take(3)
         for (queryRepo in queriesToRetry) {
-            val response = queryRepo.runQueryOnline(QueryChannelsPaginationRequest(0, 30, 30))
+            val response = queryRepo.runQueryOnline(QueryChannelsPaginationRequest(QuerySort(), 0, 30, 30))
             if (response.isSuccess) {
                 updatedChannelIds.addAll(response.data().map { it.cid })
             }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -464,7 +464,6 @@ class ChatDomainImpl private constructor(
     ): QueryChannelsControllerImpl =
         activeQueryMapImpl.getOrPut("${filter.hashCode()}-${sort.hashCode()}") {
             QueryChannelsControllerImpl(
-                QueryChannelsEntity(filter, sort),
                 filter,
                 sort,
                 client,

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -460,9 +460,9 @@ class ChatDomainImpl private constructor(
      */
     fun queryChannels(
         filter: FilterObject,
-        sort: QuerySort? = null
+        sort: QuerySort
     ): QueryChannelsControllerImpl =
-        activeQueryMapImpl.getOrPut("${filter.hashCode()}-${sort?.hashCode()}") {
+        activeQueryMapImpl.getOrPut("${filter.hashCode()}-${sort.hashCode()}") {
             QueryChannelsControllerImpl(
                 QueryChannelsEntity(filter, sort),
                 filter,

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -30,6 +30,7 @@ import io.getstream.chat.android.livedata.repository.RepositoryHelper
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
 import io.getstream.chat.android.livedata.request.QueryChannelPaginationRequest
 import io.getstream.chat.android.livedata.request.QueryChannelsPaginationRequest
+import io.getstream.chat.android.livedata.request.toAnyChannelPaginationRequest
 import io.getstream.chat.android.livedata.usecase.*
 import io.getstream.chat.android.livedata.utils.DefaultRetryPolicy
 import io.getstream.chat.android.livedata.utils.Event

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsController.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsController.kt
@@ -17,11 +17,11 @@ interface QueryChannelsController {
     /**
      * The filter used for this query
      */
-    var filter: FilterObject
+    val filter: FilterObject
     /**
      * The sort used for this query
      */
-    var sort: QuerySort?
+    val sort: QuerySort
     /**
      * When the NotificationAddedToChannelEvent is triggered the newChannelEventFilter
      * determines if the channel should be added to the query or not.
@@ -40,7 +40,7 @@ interface QueryChannelsController {
     /**
      * The list of channels
      */
-    var channels: LiveData<List<Channel>>
+    val channels: LiveData<List<Channel>>
     /**
      * If we are currently loading channels
      */

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsController.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsController.kt
@@ -28,7 +28,7 @@ interface QueryChannelsController {
      * Return true to add the channel, return false to ignore it.
      * By default it will simply add every channel for which this event is received
      */
-    var newChannelEventFilter: ((Channel, FilterObject) -> Boolean)?
+    var newChannelEventFilter: (Channel, FilterObject) -> Boolean
     /**
      * If the API call failed and we need to rerun this query
      */

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.*
 import java.util.concurrent.ConcurrentHashMap
 
 class QueryChannelsControllerImpl(
-    internal val queryEntity: QueryChannelsEntity,
     override val filter: FilterObject,
     override val sort: QuerySort,
     internal val client: ChatClient,
@@ -36,6 +35,7 @@ class QueryChannelsControllerImpl(
      * A livedata object with the channels matching this query.
      */
 
+    internal val queryEntity: QueryChannelsEntity = QueryChannelsEntity(filter, sort)
     val job = SupervisorJob()
     val scope = CoroutineScope(Dispatchers.IO + domainImpl.job + job)
 

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -19,6 +19,7 @@ import io.getstream.chat.android.livedata.entity.ChannelConfigEntity
 import io.getstream.chat.android.livedata.entity.QueryChannelsEntity
 import io.getstream.chat.android.livedata.extensions.isChannelEvent
 import io.getstream.chat.android.livedata.request.QueryChannelsPaginationRequest
+import io.getstream.chat.android.livedata.request.toQueryChannelsRequest
 import kotlinx.coroutines.*
 import java.util.concurrent.ConcurrentHashMap
 
@@ -146,7 +147,7 @@ class QueryChannelsControllerImpl(
 
         if (channels != null) {
             // first page replaces the results, second page adds to them
-            if (pagination.isFirstPage()) {
+            if (pagination.isFirstPage) {
                 setChannels(channels)
             } else {
                 addChannels(channels)
@@ -181,7 +182,7 @@ class QueryChannelsControllerImpl(
 
             domainImpl.storeStateForChannels(channelsResponse)
 
-            if (pagination.isFirstPage()) {
+            if (pagination.isFirstPage) {
                 setChannels(channelsResponse)
             } else {
                 addChannels(channelsResponse)
@@ -195,7 +196,7 @@ class QueryChannelsControllerImpl(
     }
 
     suspend fun runQuery(pagination: QueryChannelsPaginationRequest): Result<List<Channel>> {
-        val loader = if (pagination.isFirstPage()) {
+        val loader = if (pagination.isFirstPage) {
             _loading
         } else {
             _loadingMore

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -27,9 +27,9 @@ class QueryChannelsControllerImpl(
     override val filter: FilterObject,
     override val sort: QuerySort,
     internal val client: ChatClient,
-    internal val domainImpl: ChatDomainImpl,
-    override var newChannelEventFilter: ((Channel, FilterObject) -> Boolean)? = null
+    internal val domainImpl: ChatDomainImpl
 ) : QueryChannelsController {
+    override var newChannelEventFilter: (Channel, FilterObject) -> Boolean = { _, _ -> true }
     override var recoveryNeeded: Boolean = false
     /**
      * A livedata object with the channels matching this query.
@@ -68,13 +68,7 @@ class QueryChannelsControllerImpl(
     override fun addChannelIfFilterMatches(
         channel: Channel
     ) {
-        val shouldBeAdded = if (newChannelEventFilter != null) {
-            newChannelEventFilter!!(channel, queryEntity.filter)
-        } else {
-            // default to always adding the channel
-            true
-        }
-        if (shouldBeAdded) {
+        if (newChannelEventFilter(channel, filter)) {
             val channelControllerImpl = domainImpl.channel(channel)
             channelControllerImpl.updateLiveDataFromChannel(channel)
             addChannels(listOf(channel), true)

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -24,11 +24,11 @@ import kotlinx.coroutines.*
 import java.util.concurrent.ConcurrentHashMap
 
 class QueryChannelsControllerImpl(
-    internal var queryEntity: QueryChannelsEntity,
-    override var filter: FilterObject,
-    override var sort: QuerySort?,
-    internal var client: ChatClient,
-    internal var domainImpl: ChatDomainImpl,
+    internal val queryEntity: QueryChannelsEntity,
+    override val filter: FilterObject,
+    override val sort: QuerySort,
+    internal val client: ChatClient,
+    internal val domainImpl: ChatDomainImpl,
     override var newChannelEventFilter: ((Channel, FilterObject) -> Boolean)? = null
 ) : QueryChannelsController {
     override var recoveryNeeded: Boolean = false

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -134,7 +134,7 @@ class QueryChannelsControllerImpl(
     }
 
     suspend fun runQueryOnline(pagination: QueryChannelsPaginationRequest): Result<List<Channel>> {
-        val request = pagination.toQueryChannelsRequest(queryEntity.filter, domainImpl.userPresence)
+        val request = pagination.toQueryChannelsRequest(filter, domainImpl.userPresence)
         // next run the actual query
         val response = client.queryChannels(request).execute()
 

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -114,29 +114,12 @@ class QueryChannelsControllerImpl(
         return runQuery(QueryChannelsPaginationRequest(sort, 0, limit, messageLimit))
     }
 
-    fun paginateChannelIds(channelIds: MutableSet<String>, pagination: QueryChannelsPaginationRequest): List<String> {
-        var min = pagination.channelOffset
-        var max = pagination.channelOffset + pagination.channelLimit
-        if (max > channelIds.size - 1) {
-            max = channelIds.size - 1
-        }
-
-        return if (min > channelIds.size - 1) {
-            listOf()
-        } else {
-            channelIds.toList().slice(IntRange(min, max))
-        }
-    }
-
     suspend fun runQueryOffline(pagination: QueryChannelsPaginationRequest): List<Channel>? {
-        var queryEntity = domainImpl.repos.queryChannels.select(queryEntity.id)
+        val queryEntity = domainImpl.repos.queryChannels.select(queryEntity.id)
         var channels: List<Channel>? = null
 
         if (queryEntity != null) {
-
-            var channelIds = paginateChannelIds(queryEntity.channelCids, pagination)
-
-            val channelPairs = domainImpl.selectAndEnrichChannels(channelIds, pagination)
+            val channelPairs = domainImpl.selectAndEnrichChannels(queryEntity.channelCids.toList(), pagination)
             for (p in channelPairs) {
                 val channelRepo = domainImpl.channel(p.channel)
                 channelRepo.updateLiveDataFromChannelEntityPair(p)

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -56,7 +56,7 @@ class QueryChannelsControllerImpl(
 
     fun loadMoreRequest(limit: Int = 30, messageLimit: Int = 10): QueryChannelsPaginationRequest {
         val channels = _channels.value ?: ConcurrentHashMap()
-        return QueryChannelsPaginationRequest(channels.size, limit, messageLimit)
+        return QueryChannelsPaginationRequest(sort, channels.size, limit, messageLimit)
     }
 
     fun handleEvents(events: List<ChatEvent>) {
@@ -111,7 +111,7 @@ class QueryChannelsControllerImpl(
     }
 
     suspend fun query(limit: Int = 30, messageLimit: Int = 10): Result<List<Channel>> {
-        return runQuery(QueryChannelsPaginationRequest(0, limit, messageLimit))
+        return runQuery(QueryChannelsPaginationRequest(sort, 0, limit, messageLimit))
     }
 
     fun paginateChannelIds(channelIds: MutableSet<String>, pagination: QueryChannelsPaginationRequest): List<String> {
@@ -157,7 +157,7 @@ class QueryChannelsControllerImpl(
     }
 
     suspend fun runQueryOnline(pagination: QueryChannelsPaginationRequest): Result<List<Channel>> {
-        val request = pagination.toQueryChannelsRequest(queryEntity.filter, queryEntity.sort, domainImpl.userPresence)
+        val request = pagination.toQueryChannelsRequest(queryEntity.filter, domainImpl.userPresence)
         // next run the actual query
         val response = client.queryChannels(request).execute()
 

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/QueryChannelsEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/QueryChannelsEntity.kt
@@ -7,14 +7,14 @@ import io.getstream.chat.android.client.utils.FilterObject
 import java.util.*
 
 @Entity(tableName = "stream_channel_query")
-data class QueryChannelsEntity(var filter: FilterObject, val sort: QuerySort? = null) {
+data class QueryChannelsEntity(var filter: FilterObject, val sort: QuerySort) {
     @PrimaryKey
     var id: String
 
     init {
         // ugly hack to cleanup the filter object to prevent issues with filter object equality
         filter = FilterObject(filter.toMap())
-        id = (Objects.hash(filter.toMap()) + Objects.hash(sort?.data)).toString()
+        id = (Objects.hash(filter.toMap()) + Objects.hash(sort.data)).toString()
     }
 
     var channelCids: MutableSet<String> = sortedSetOf()

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/QueryChannelsEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/QueryChannelsEntity.kt
@@ -17,7 +17,7 @@ data class QueryChannelsEntity(var filter: FilterObject, val sort: QuerySort) {
         id = (Objects.hash(filter.toMap()) + Objects.hash(sort.data)).toString()
     }
 
-    var channelCids: MutableSet<String> = sortedSetOf()
+    var channelCids: List<String> = listOf()
 
     /** we track when the query was created and updated so we can clear out old results */
     var createdAt: Date? = null

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/request/AnyChannelPaginationRequest.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/request/AnyChannelPaginationRequest.kt
@@ -1,10 +1,12 @@
 package io.getstream.chat.android.livedata.request
 
 import io.getstream.chat.android.client.api.models.Pagination
+import io.getstream.chat.android.client.api.models.QuerySort
 
 internal class AnyChannelPaginationRequest(var messageLimit: Int = 30) {
     var messageFilterDirection: Pagination? = null
     var messageFilterValue: String = ""
+    var sort: QuerySort = QuerySort()
 
     var channelLimit: Int = 30
     var channelOffset: Int = 0

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/request/Mapper.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/request/Mapper.kt
@@ -1,0 +1,23 @@
+package io.getstream.chat.android.livedata.request
+
+import io.getstream.chat.android.client.api.models.QueryChannelsRequest
+import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.client.utils.FilterObject
+
+internal fun QueryChannelsPaginationRequest.toAnyChannelPaginationRequest(): AnyChannelPaginationRequest =
+    AnyChannelPaginationRequest().apply {
+        this.channelLimit = channelLimit
+        this.channelOffset = channelOffset
+        this.messageLimit = messageLimit
+    }
+
+internal fun QueryChannelsPaginationRequest.toQueryChannelsRequest(filter: FilterObject, sort: QuerySort?, userPresence: Boolean): QueryChannelsRequest {
+    val querySort = sort ?: QuerySort()
+    var request = QueryChannelsRequest(filter, channelOffset, channelLimit, querySort)
+
+    request = request.withMessages(messageLimit)
+    if (userPresence) {
+        request = request.withPresence()
+    }
+    return request.withWatch()
+}

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/request/Mapper.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/request/Mapper.kt
@@ -1,7 +1,6 @@
 package io.getstream.chat.android.livedata.request
 
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
-import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.utils.FilterObject
 
 internal fun QueryChannelsPaginationRequest.toAnyChannelPaginationRequest(): AnyChannelPaginationRequest =
@@ -11,9 +10,8 @@ internal fun QueryChannelsPaginationRequest.toAnyChannelPaginationRequest(): Any
         this.messageLimit = messageLimit
     }
 
-internal fun QueryChannelsPaginationRequest.toQueryChannelsRequest(filter: FilterObject, sort: QuerySort?, userPresence: Boolean): QueryChannelsRequest {
-    val querySort = sort ?: QuerySort()
-    var request = QueryChannelsRequest(filter, channelOffset, channelLimit, querySort)
+internal fun QueryChannelsPaginationRequest.toQueryChannelsRequest(filter: FilterObject, userPresence: Boolean): QueryChannelsRequest {
+    var request = QueryChannelsRequest(filter, channelOffset, channelLimit, sort)
 
     request = request.withMessages(messageLimit)
     if (userPresence) {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/request/Mapper.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/request/Mapper.kt
@@ -8,6 +8,7 @@ internal fun QueryChannelsPaginationRequest.toAnyChannelPaginationRequest(): Any
         this.channelLimit = channelLimit
         this.channelOffset = channelOffset
         this.messageLimit = messageLimit
+        this.sort = sort
     }
 
 internal fun QueryChannelsPaginationRequest.toQueryChannelsRequest(filter: FilterObject, userPresence: Boolean): QueryChannelsRequest {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/request/QueryChannelsPaginationRequest.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/request/QueryChannelsPaginationRequest.kt
@@ -1,11 +1,9 @@
 package io.getstream.chat.android.livedata.request
 
-/**
- * Paginate query channels on the queryChannels repo
- * Similar to QueryChannelsRequest but without the watch, filter and sort params
- * Since those are provided by the QueryChannelsRepo
- */
+import io.getstream.chat.android.client.api.models.QuerySort
+
 data class QueryChannelsPaginationRequest(
+    val sort: QuerySort,
     val channelOffset: Int = 0,
     val channelLimit: Int = 30,
     val messageLimit: Int = 10

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/request/QueryChannelsPaginationRequest.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/request/QueryChannelsPaginationRequest.kt
@@ -10,9 +10,9 @@ import io.getstream.chat.android.client.utils.FilterObject
  * Since those are provided by the QueryChannelsRepo
  */
 data class QueryChannelsPaginationRequest(
-    var channelOffset: Int = 0,
-    var channelLimit: Int = 30,
-    var messageLimit: Int = 10
+    val channelOffset: Int = 0,
+    val channelLimit: Int = 30,
+    val messageLimit: Int = 10
 ) {
 
     fun isFirstPage(): Boolean {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/request/QueryChannelsPaginationRequest.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/request/QueryChannelsPaginationRequest.kt
@@ -1,9 +1,5 @@
 package io.getstream.chat.android.livedata.request
 
-import io.getstream.chat.android.client.api.models.QueryChannelsRequest
-import io.getstream.chat.android.client.api.models.QuerySort
-import io.getstream.chat.android.client.utils.FilterObject
-
 /**
  * Paginate query channels on the queryChannels repo
  * Similar to QueryChannelsRequest but without the watch, filter and sort params
@@ -15,26 +11,6 @@ data class QueryChannelsPaginationRequest(
     val messageLimit: Int = 10
 ) {
 
-    fun isFirstPage(): Boolean {
-        return channelOffset == 0
-    }
-
-    internal fun toAnyChannelPaginationRequest(): AnyChannelPaginationRequest {
-        return AnyChannelPaginationRequest().apply {
-            this.channelLimit = channelLimit
-            this.channelOffset = channelOffset
-            this.messageLimit = messageLimit
-        }
-    }
-
-    fun toQueryChannelsRequest(filter: FilterObject, sort: QuerySort?, userPresence: Boolean): QueryChannelsRequest {
-        val querySort = sort ?: QuerySort()
-        var request = QueryChannelsRequest(filter, channelOffset, channelLimit, querySort)
-
-        request = request.withMessages(messageLimit)
-        if (userPresence) {
-            request = request.withPresence()
-        }
-        return request.withWatch()
-    }
+    val isFirstPage: Boolean
+        get() = channelOffset == 0
 }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImpl.kt
@@ -25,11 +25,11 @@ interface QueryChannels {
      * @see io.getstream.chat.android.client.api.models.QuerySort
      * @see <a href="https://getstream.io/chat/docs/query_channels/?language=kotlin">Filter syntax</a>
      */
-    operator fun invoke(filter: FilterObject, sort: QuerySort? = null, limit: Int = 30, messageLimit: Int = 10): Call2<QueryChannelsController>
+    operator fun invoke(filter: FilterObject, sort: QuerySort, limit: Int = 30, messageLimit: Int = 10): Call2<QueryChannelsController>
 }
 
 class QueryChannelsImpl(var domainImpl: ChatDomainImpl) : QueryChannels {
-    override operator fun invoke(filter: FilterObject, sort: QuerySort?, limit: Int, messageLimit: Int): Call2<QueryChannelsController> {
+    override operator fun invoke(filter: FilterObject, sort: QuerySort, limit: Int, messageLimit: Int): Call2<QueryChannelsController> {
         val queryChannelsControllerImpl = domainImpl.queryChannels(filter, sort)
         val queryChannelsController: QueryChannelsController = queryChannelsControllerImpl
         val runnable = suspend {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsLoadMoreImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsLoadMoreImpl.kt
@@ -19,11 +19,11 @@ interface QueryChannelsLoadMore {
      * @see io.getstream.chat.android.client.api.models.QuerySort
      * @see <a href="https://getstream.io/chat/docs/query_channels/?language=kotlin">Filter syntax</a>
      */
-    operator fun invoke(filter: FilterObject, sort: QuerySort?, limit: Int = 30, messageLimit: Int = 10): Call2<List<Channel>>
+    operator fun invoke(filter: FilterObject, sort: QuerySort, limit: Int = 30, messageLimit: Int = 10): Call2<List<Channel>>
 }
 
 class QueryChannelsLoadMoreImpl(var domainImpl: ChatDomainImpl) : QueryChannelsLoadMore {
-    override operator fun invoke(filter: FilterObject, sort: QuerySort?, limit: Int, messageLimit: Int): Call2<List<Channel>> {
+    override operator fun invoke(filter: FilterObject, sort: QuerySort, limit: Int, messageLimit: Int): Call2<List<Channel>> {
         val runnable = suspend {
             val queryChannelsController = domainImpl.queryChannels(filter, sort)
             queryChannelsController.loadMore(limit, messageLimit)

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/BaseConnectedIntegrationTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/BaseConnectedIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.livedata.entity.QueryChannelsEntity
 import io.getstream.chat.android.livedata.utils.EventObserver
@@ -87,9 +88,9 @@ open class BaseConnectedIntegrationTest : BaseDomainTest() {
         runBlocking(Dispatchers.IO) { chatDomainImpl.repos.configs.insertConfigs(mutableMapOf("messaging" to data.config1)) }
         channelControllerImpl = chatDomainImpl.channel(data.channel1.type, data.channel1.id)
         channelControllerImpl.updateLiveDataFromChannel(data.channel1)
-        query = QueryChannelsEntity(data.filter1, null)
+        query = QueryChannelsEntity(data.filter1, QuerySort())
 
-        queryControllerImpl = chatDomainImpl.queryChannels(data.filter1)
+        queryControllerImpl = chatDomainImpl.queryChannels(data.filter1, QuerySort())
 
         Truth.assertThat(client.isSocketConnected()).isTrue()
 

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/BaseDisconnectedIntegrationTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/BaseDisconnectedIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.livedata.entity.QueryChannelsEntity
@@ -85,9 +86,9 @@ open class BaseDisconnectedIntegrationTest : BaseDomainTest() {
         runBlocking(Dispatchers.IO) { chatDomainImpl.repos.configs.insertConfigs(mutableMapOf("messaging" to data.config1)) }
         channelControllerImpl = chatDomainImpl.channel(data.channel1.type, data.channel1.id)
         channelControllerImpl.updateLiveDataFromChannel(data.channel1)
-        query = QueryChannelsEntity(data.filter1, null)
+        query = QueryChannelsEntity(data.filter1, QuerySort())
 
-        queryControllerImpl = chatDomainImpl.queryChannels(data.filter1)
+        queryControllerImpl = chatDomainImpl.queryChannels(data.filter1, QuerySort())
 
         Truth.assertThat(client.isSocketConnected()).isFalse()
 

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest.kt
@@ -15,6 +15,7 @@ import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.api.models.WatchChannelRequest
 import io.getstream.chat.android.client.controllers.ChannelController
 import io.getstream.chat.android.client.errors.ChatError
@@ -223,8 +224,8 @@ open class BaseDomainTest {
         channelControllerImpl = chatDomainImpl.channel(data.channel1.type, data.channel1.id)
         channelControllerImpl.updateLiveDataFromChannel(data.channel1)
 
-        query = QueryChannelsEntity(data.filter1, null)
+        query = QueryChannelsEntity(data.filter1, QuerySort())
 
-        queryControllerImpl = chatDomainImpl.queryChannels(data.filter1)
+        queryControllerImpl = chatDomainImpl.queryChannels(data.filter1, QuerySort())
     }
 }

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/Mother.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/Mother.kt
@@ -2,6 +2,8 @@ package io.getstream.chat.android.livedata
 
 import io.getstream.chat.android.client.models.*
 import io.getstream.chat.android.client.utils.SyncStatus
+import io.getstream.chat.android.livedata.entity.ChannelEntity
+import io.getstream.chat.android.livedata.entity.ChannelEntityPair
 import java.io.File
 import java.util.*
 import java.util.concurrent.ThreadLocalRandom
@@ -127,6 +129,62 @@ fun randomMessage(
     extraData,
     silent
 )
+
+fun randomChannel(
+    cid: String = randomString(),
+    id: String = randomString(),
+    type: String = randomString(),
+    watcherCount: Int = randomInt(),
+    frozen: Boolean = randomBoolean(),
+    lastMessageAt: Date? = randomDate(),
+    createdAt: Date? = randomDate(),
+    deletedAt: Date? = randomDate(),
+    updatedAt: Date? = randomDate(),
+    syncStatus: SyncStatus = randomSyncStatus(),
+    memberCount: Int = randomInt(),
+    messages: List<Message> = mutableListOf(),
+    members: List<Member> = mutableListOf(),
+    watchers: List<Watcher> = mutableListOf(),
+    read: List<ChannelUserRead> = mutableListOf(),
+    config: Config = Config(),
+    createdBy: User = randomUser(),
+    unreadCount: Int? = randomInt(),
+    team: String = randomString(),
+    hidden: Boolean? = randomBoolean(),
+    hiddenMessagesBefore: Date? = randomDate()
+): Channel = Channel(
+    cid = cid,
+    id = id,
+    type = type,
+    watcherCount = watcherCount,
+    frozen = frozen,
+    lastMessageAt = lastMessageAt,
+    createdAt = createdAt,
+    deletedAt = deletedAt,
+    updatedAt = updatedAt,
+    syncStatus = syncStatus,
+    memberCount = memberCount,
+    messages = messages,
+    members = members,
+    watchers = watchers,
+    read = read,
+    config = config,
+    createdBy = createdBy,
+    unreadCount = unreadCount,
+    team = team,
+    hidden = hidden,
+    hiddenMessagesBefore = hiddenMessagesBefore
+)
+
+fun randomChannelEntity(
+    type: String = randomString(),
+    channelId: String = randomString()
+): ChannelEntity = ChannelEntity(type, channelId)
+
+fun randomChannelEntityPair(
+    channel: Channel = randomChannel(),
+    channelEntity: ChannelEntity = randomChannelEntity()
+): ChannelEntityPair = ChannelEntityPair(channel, channelEntity)
 
 fun randomDate() = Date(randomLong())
 

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/PaginationTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/PaginationTest.kt
@@ -1,0 +1,168 @@
+package io.getstream.chat.android.livedata
+
+import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.livedata.entity.ChannelEntityPair
+import io.getstream.chat.android.livedata.extensions.applyPagination
+import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class PaginationTest {
+
+    @ParameterizedTest
+    @MethodSource("io.getstream.chat.android.livedata.PaginationTest#createPaginationInput")
+    internal fun `Should return a list of channelEntityPairs properly sorted by pagination param`(
+        inputList: List<ChannelEntityPair>,
+        pagination: AnyChannelPaginationRequest,
+        expectedList: List<ChannelEntityPair>
+    ) {
+        inputList.applyPagination(pagination) `should be equal to` expectedList
+    }
+
+    companion object {
+        @JvmStatic
+        fun createPaginationInput() = listOf(
+            Arguments.of(listOf<ChannelEntityPair>(), AnyChannelPaginationRequest(), listOf<ChannelEntityPair>()),
+            listOf(randomChannelEntityPair()).let { Arguments.of(it, AnyChannelPaginationRequest(), it) },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b"))
+            ).let { Arguments.of(it, AnyChannelPaginationRequest(), it) },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "b")),
+                randomChannelEntityPair(channel = randomChannel(cid = "a"))
+            ).let { Arguments.of(it, AnyChannelPaginationRequest(), it) },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b"))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply { asc("cid") }
+                    },
+                    it
+                )
+            },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "b")),
+                randomChannelEntityPair(channel = randomChannel(cid = "a"))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply { asc("cid") }
+                    },
+                    it.reversed()
+                )
+            },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b"))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply { desc("cid") }
+                    },
+                    it.reversed()
+                )
+            },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "b")),
+                randomChannelEntityPair(channel = randomChannel(cid = "a"))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply { desc("cid") }
+                    },
+                    it
+                )
+            },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "b"))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply {
+                            asc("cid")
+                            asc("type")
+                        }
+                    },
+                    it
+                )
+            },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "b")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "a"))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply {
+                            asc("cid")
+                            asc("type")
+                        }
+                    },
+                    listOf(it[0], it[2], it[1])
+                )
+            },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "b"))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply {
+                            asc("cid")
+                            desc("type")
+                        }
+                    },
+                    listOf(it[0], it[2], it[1])
+                )
+            },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "b")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "a"))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply {
+                            asc("cid")
+                            desc("type")
+                        }
+                    },
+                    it
+                )
+            },
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "a")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "b")),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", type = "a"))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply {
+                            asc("cid")
+                            asc("SomeInvalidField")
+                            desc("type")
+                        }
+                    },
+                    it
+                )
+            }
+        )
+    }
+}

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/PerformanceTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/PerformanceTest.kt
@@ -32,7 +32,7 @@ class PerformanceTest : BaseConnectedMockedTest() {
             counter.onEvent(channels)
         }
         // Insert a query, channel and message into offline storage
-        val query = QueryChannelsEntity(data.filter1, QuerySort()).apply { channelCids = sortedSetOf(data.channel1.cid) }
+        val query = QueryChannelsEntity(data.filter1, QuerySort()).apply { channelCids = listOf(data.channel1.cid) }
         chatDomainImpl.repos.channels.insertChannel(data.channel1)
         chatDomainImpl.repos.messages.insertMessage(data.message1)
         chatDomainImpl.repos.queryChannels.insert(query)

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/PerformanceTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/PerformanceTest.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.livedata
 import androidx.recyclerview.widget.DiffUtil
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.entity.QueryChannelsEntity
@@ -19,7 +20,7 @@ class PerformanceTest : BaseConnectedMockedTest() {
     @Test
     fun channels() = runBlocking(Dispatchers.IO) {
         var channelControllerImpl = chatDomainImpl.channel(data.channel1)
-        val queryChannelsControllerImpl = chatDomainImpl.queryChannels(data.filter1)
+        val queryChannelsControllerImpl = chatDomainImpl.queryChannels(data.filter1, QuerySort())
 
         var counter = LiveDiffCounter { old: List<Channel>, new: List<Channel> ->
             DiffUtil.calculateDiff(ChannelDiffCallback(old, new), true)
@@ -31,7 +32,7 @@ class PerformanceTest : BaseConnectedMockedTest() {
             counter.onEvent(channels)
         }
         // Insert a query, channel and message into offline storage
-        val query = QueryChannelsEntity(data.filter1, null).apply { channelCids = sortedSetOf(data.channel1.cid) }
+        val query = QueryChannelsEntity(data.filter1, QuerySort()).apply { channelCids = sortedSetOf(data.channel1.cid) }
         chatDomainImpl.repos.channels.insertChannel(data.channel1)
         chatDomainImpl.repos.messages.insertMessage(data.message1)
         chatDomainImpl.repos.queryChannels.insert(query)

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplInsertDomainTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplInsertDomainTest.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.controller
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.utils.SyncStatus
@@ -126,8 +127,7 @@ class ChannelControllerImplInsertDomainTest : BaseConnectedIntegrationTest() {
     @Test
     fun insertQuery() = runBlocking(Dispatchers.IO) {
         val filter = Filters.eq("type", "messaging")
-        val sort = null
-        val query = QueryChannelsEntity(filter, sort)
+        val query = QueryChannelsEntity(filter, QuerySort())
         query.channelCids = sortedSetOf("messaging:123", "messaging:234")
         chatDomainImpl.repos.queryChannels.insert(query)
     }

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplInsertDomainTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplInsertDomainTest.kt
@@ -128,7 +128,7 @@ class ChannelControllerImplInsertDomainTest : BaseConnectedIntegrationTest() {
     fun insertQuery() = runBlocking(Dispatchers.IO) {
         val filter = Filters.eq("type", "messaging")
         val query = QueryChannelsEntity(filter, QuerySort())
-        query.channelCids = sortedSetOf("messaging:123", "messaging:234")
+        query.channelCids = listOf("messaging:123", "messaging:234")
         chatDomainImpl.repos.queryChannels.insert(query)
     }
 

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.controller
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.utils.FilterObject
 import io.getstream.chat.android.livedata.BaseConnectedIntegrationTest
@@ -36,7 +37,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
     @Test
     fun newChannelFiltered() = runBlocking(Dispatchers.IO) {
         val request = QueryChannelsPaginationRequest()
-        val queryChannelsController = chatDomainImpl.queryChannels(data.filter2)
+        val queryChannelsController = chatDomainImpl.queryChannels(data.filter2, QuerySort())
         queryChannelsController.newChannelEventFilter = { channel: Channel, filterObject: FilterObject ->
             // ignore everything
             false

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
@@ -73,7 +73,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
     fun offlineRunQuery() = runBlocking(Dispatchers.IO) {
         // insert the query result into offline storage
         val query = QueryChannelsEntity(query.filter, query.sort)
-        query.channelCids = sortedSetOf(data.channel1.cid)
+        query.channelCids = listOf(data.channel1.cid)
         chatDomainImpl.repos.queryChannels.insert(query)
         chatDomainImpl.repos.messages.insertMessage(data.message1)
         chatDomainImpl.storeStateForChannel(data.channel1)
@@ -89,7 +89,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
     fun onlineRunQuery() = runBlocking(Dispatchers.IO) {
         // insert the query result into offline storage
         val query = QueryChannelsEntity(query.filter, query.sort)
-        query.channelCids = sortedSetOf(data.channel1.cid)
+        query.channelCids = listOf(data.channel1.cid)
         chatDomainImpl.repos.queryChannels.insert(query)
         chatDomainImpl.storeStateForChannel(data.channel1)
         chatDomainImpl.setOffline()

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
@@ -54,23 +54,6 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
     }
 
     @Test
-    fun testChannelIdPagination() {
-        val list = sortedSetOf("a", "b", "c")
-
-        var sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(QuerySort(), 0, 5))
-        Truth.assertThat(sub).isEqualTo(listOf("a", "b", "c"))
-
-        sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(QuerySort(), 1, 2))
-        Truth.assertThat(sub).isEqualTo(listOf("b", "c"))
-
-        sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(QuerySort(), 3, 2))
-        Truth.assertThat(sub).isEqualTo(listOf<String>())
-
-        sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(QuerySort(), 4, 2))
-        Truth.assertThat(sub).isEqualTo(listOf<String>())
-    }
-
-    @Test
     @Ignore("mock me")
     fun testLoadMore() = runBlocking(Dispatchers.IO) {
         val paginate = QueryChannelsPaginationRequest(QuerySort(), 0, 2)

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
@@ -20,7 +20,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun newChannelAdded() = runBlocking(Dispatchers.IO) {
-        val request = QueryChannelsPaginationRequest()
+        val request = QueryChannelsPaginationRequest(QuerySort())
         queryControllerImpl.runQuery(request)
         var channels = queryControllerImpl.channels.getOrAwaitValue()
         val oldSize = channels.size
@@ -36,7 +36,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun newChannelFiltered() = runBlocking(Dispatchers.IO) {
-        val request = QueryChannelsPaginationRequest()
+        val request = QueryChannelsPaginationRequest(QuerySort())
         val queryChannelsController = chatDomainImpl.queryChannels(data.filter2, QuerySort())
         queryChannelsController.newChannelEventFilter = { channel: Channel, filterObject: FilterObject ->
             // ignore everything
@@ -57,23 +57,23 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
     fun testChannelIdPagination() {
         val list = sortedSetOf("a", "b", "c")
 
-        var sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(0, 5))
+        var sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(QuerySort(), 0, 5))
         Truth.assertThat(sub).isEqualTo(listOf("a", "b", "c"))
 
-        sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(1, 2))
+        sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(QuerySort(), 1, 2))
         Truth.assertThat(sub).isEqualTo(listOf("b", "c"))
 
-        sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(3, 2))
+        sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(QuerySort(), 3, 2))
         Truth.assertThat(sub).isEqualTo(listOf<String>())
 
-        sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(4, 2))
+        sub = queryControllerImpl.paginateChannelIds(list, QueryChannelsPaginationRequest(QuerySort(), 4, 2))
         Truth.assertThat(sub).isEqualTo(listOf<String>())
     }
 
     @Test
     @Ignore("mock me")
     fun testLoadMore() = runBlocking(Dispatchers.IO) {
-        val paginate = QueryChannelsPaginationRequest(0, 2)
+        val paginate = QueryChannelsPaginationRequest(QuerySort(), 0, 2)
         val result = queryControllerImpl.runQuery(paginate)
         assertSuccess(result)
         var channels = queryControllerImpl.channels.getOrAwaitValue()
@@ -95,7 +95,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
         chatDomainImpl.repos.messages.insertMessage(data.message1)
         chatDomainImpl.storeStateForChannel(data.channel1)
         chatDomainImpl.setOffline()
-        val channels = queryControllerImpl.runQueryOffline(QueryChannelsPaginationRequest(0, 2))
+        val channels = queryControllerImpl.runQueryOffline(QueryChannelsPaginationRequest(query.sort, 0, 2))
         // should return 1 since only 1 is stored in offline storage
         Truth.assertThat(channels?.size).isEqualTo(1)
         // verify we load messages correctly
@@ -110,7 +110,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
         chatDomainImpl.repos.queryChannels.insert(query)
         chatDomainImpl.storeStateForChannel(data.channel1)
         chatDomainImpl.setOffline()
-        queryControllerImpl.runQuery(QueryChannelsPaginationRequest(0, 2))
+        queryControllerImpl.runQuery(QueryChannelsPaginationRequest(query.sort, 0, 2))
         val channels = queryControllerImpl.channels.getOrAwaitValue()
         // should return 1 since only 1 is stored in offline storage
         Truth.assertThat(channels.size).isEqualTo(1)

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/repository/QueryChannelsImplRepositoryTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/repository/QueryChannelsImplRepositoryTest.kt
@@ -17,7 +17,7 @@ class QueryChannelsImplRepositoryTest : BaseDomainTest() {
     @Test
     fun testInsertAndRead() = runBlocking(Dispatchers.IO) {
         val queryChannelsEntity = QueryChannelsEntity(data.filter1, QuerySort())
-        queryChannelsEntity.channelCids = sortedSetOf("a", "b", "c")
+        queryChannelsEntity.channelCids = listOf("a", "b", "c")
         repo.insert(queryChannelsEntity)
         val entity = repo.select(queryChannelsEntity.id)
         Truth.assertThat(queryChannelsEntity).isEqualTo(entity)
@@ -26,21 +26,12 @@ class QueryChannelsImplRepositoryTest : BaseDomainTest() {
     @Test
     fun testUpdate() = runBlocking(Dispatchers.IO) {
         val queryChannelsEntity = QueryChannelsEntity(data.filter1, QuerySort())
-        queryChannelsEntity.channelCids = sortedSetOf("a", "b", "c")
+        queryChannelsEntity.channelCids = listOf("a", "b", "c")
         repo.insert(queryChannelsEntity)
-        queryChannelsEntity.channelCids = sortedSetOf("a", "b", "c", "d")
+        queryChannelsEntity.channelCids = listOf("a", "b", "c", "d")
         repo.insert(queryChannelsEntity)
 
         val entity = repo.select(queryChannelsEntity.id)
         Truth.assertThat(entity).isEqualTo(queryChannelsEntity)
-    }
-
-    @Test
-    fun testOrdering() = runBlocking(Dispatchers.IO) {
-        val queryChannelsEntity = QueryChannelsEntity(data.filter1, QuerySort())
-        queryChannelsEntity.channelCids = mutableSetOf("a", "b", "c")
-        queryChannelsEntity.channelCids.addAll(listOf("1"))
-
-        Truth.assertThat(queryChannelsEntity.channelCids.toList()[3]).isEqualTo("1")
     }
 }

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/repository/QueryChannelsImplRepositoryTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/repository/QueryChannelsImplRepositoryTest.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.livedata.BaseDomainTest
 import io.getstream.chat.android.livedata.entity.QueryChannelsEntity
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +16,7 @@ class QueryChannelsImplRepositoryTest : BaseDomainTest() {
 
     @Test
     fun testInsertAndRead() = runBlocking(Dispatchers.IO) {
-        val queryChannelsEntity = QueryChannelsEntity(data.filter1, null)
+        val queryChannelsEntity = QueryChannelsEntity(data.filter1, QuerySort())
         queryChannelsEntity.channelCids = sortedSetOf("a", "b", "c")
         repo.insert(queryChannelsEntity)
         val entity = repo.select(queryChannelsEntity.id)
@@ -24,7 +25,7 @@ class QueryChannelsImplRepositoryTest : BaseDomainTest() {
 
     @Test
     fun testUpdate() = runBlocking(Dispatchers.IO) {
-        val queryChannelsEntity = QueryChannelsEntity(data.filter1, null)
+        val queryChannelsEntity = QueryChannelsEntity(data.filter1, QuerySort())
         queryChannelsEntity.channelCids = sortedSetOf("a", "b", "c")
         repo.insert(queryChannelsEntity)
         queryChannelsEntity.channelCids = sortedSetOf("a", "b", "c", "d")
@@ -36,7 +37,7 @@ class QueryChannelsImplRepositoryTest : BaseDomainTest() {
 
     @Test
     fun testOrdering() = runBlocking(Dispatchers.IO) {
-        val queryChannelsEntity = QueryChannelsEntity(data.filter1, null)
+        val queryChannelsEntity = QueryChannelsEntity(data.filter1, QuerySort())
         queryChannelsEntity.channelCids = mutableSetOf("a", "b", "c")
         queryChannelsEntity.channelCids.addAll(listOf("1"))
 

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
@@ -42,7 +42,7 @@ class HideChannelImplTest : BaseConnectedIntegrationTest() {
         // setup the query channel controller
         chatDomain.useCases.queryChannels(data.filter1, QuerySort(), 0, 10).execute()
         var queryChannelsControllerImpl = chatDomainImpl.queryChannels(data.filter1, QuerySort())
-        queryChannelsControllerImpl.runQueryOffline(QueryChannelsPaginationRequest())
+        queryChannelsControllerImpl.runQueryOffline(QueryChannelsPaginationRequest(QuerySort()))
 
         // verify we have 1 channel in the result list and that it's hidden
         val channelController = chatDomainImpl.channel(data.channel1)

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
@@ -36,7 +36,7 @@ class HideChannelImplTest : BaseConnectedIntegrationTest() {
         val channelEntity = ChannelEntity(data.channel1)
         channelEntity.hidden = true
         chatDomainImpl.repos.channels.insert(channelEntity)
-        val query = QueryChannelsEntity(data.filter1, QuerySort()).apply { channelCids = sortedSetOf<String>(data.channel1.cid) }
+        val query = QueryChannelsEntity(data.filter1, QuerySort()).apply { channelCids = listOf(data.channel1.cid) }
         chatDomainImpl.repos.queryChannels.insert(query)
 
         // setup the query channel controller

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.usecase
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.livedata.BaseConnectedIntegrationTest
 import io.getstream.chat.android.livedata.entity.ChannelEntity
 import io.getstream.chat.android.livedata.entity.QueryChannelsEntity
@@ -35,12 +36,12 @@ class HideChannelImplTest : BaseConnectedIntegrationTest() {
         val channelEntity = ChannelEntity(data.channel1)
         channelEntity.hidden = true
         chatDomainImpl.repos.channels.insert(channelEntity)
-        val query = QueryChannelsEntity(data.filter1, null).apply { channelCids = sortedSetOf<String>(data.channel1.cid) }
+        val query = QueryChannelsEntity(data.filter1, QuerySort()).apply { channelCids = sortedSetOf<String>(data.channel1.cid) }
         chatDomainImpl.repos.queryChannels.insert(query)
 
         // setup the query channel controller
-        chatDomain.useCases.queryChannels(data.filter1, null, 0, 10).execute()
-        var queryChannelsControllerImpl = chatDomainImpl.queryChannels(data.filter1, null)
+        chatDomain.useCases.queryChannels(data.filter1, QuerySort(), 0, 10).execute()
+        var queryChannelsControllerImpl = chatDomainImpl.queryChannels(data.filter1, QuerySort())
         queryChannelsControllerImpl.runQueryOffline(QueryChannelsPaginationRequest())
 
         // verify we have 1 channel in the result list and that it's hidden

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImplLoadMoreTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImplLoadMoreTest.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.usecase
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.livedata.BaseConnectedIntegrationTest
 import io.getstream.chat.android.livedata.utils.getOrAwaitValue
 import kotlinx.coroutines.Dispatchers
@@ -17,12 +18,12 @@ class QueryChannelsImplLoadMoreTest : BaseConnectedIntegrationTest() {
     @Ignore("mock me")
     fun loadMoreTest() = runBlocking(Dispatchers.IO) {
         // use case style syntax
-        var queryChannelResult = chatDomain.useCases.queryChannels(data.filter1, null, 0).execute()
+        var queryChannelResult = chatDomain.useCases.queryChannels(data.filter1, QuerySort(), 0).execute()
         assertSuccess(queryChannelResult)
         val queryChannelsController = queryChannelResult.data()
 
         var loadMoreResult =
-            chatDomain.useCases.queryChannelsLoadMore(data.filter1, null, 1).execute()
+            chatDomain.useCases.queryChannelsLoadMore(data.filter1, QuerySort(), 1).execute()
         assertSuccess(loadMoreResult)
 
         var channels = queryChannelsController.channels.getOrAwaitValue()

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImplTest.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.usecase
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.events.MessageReadEvent
 import io.getstream.chat.android.client.events.NewMessageEvent
 import io.getstream.chat.android.client.models.Message
@@ -21,7 +22,7 @@ class QueryChannelsImplTest : BaseConnectedIntegrationTest() {
     @Ignore("mock me")
     fun filter() = runBlocking(Dispatchers.IO) {
         // use case style syntax
-        var queryChannelResult = chatDomain.useCases.queryChannels(data.filter1, null).execute()
+        var queryChannelResult = chatDomain.useCases.queryChannels(data.filter1, QuerySort()).execute()
         assertSuccess(queryChannelResult)
         val queryChannelsController = queryChannelResult.data()
         val channels = queryChannelsController.channels.getOrAwaitValue()
@@ -34,7 +35,7 @@ class QueryChannelsImplTest : BaseConnectedIntegrationTest() {
     @Test
     @Ignore("mock me")
     fun unreadCountNewMessage() = runBlocking(Dispatchers.IO) {
-        val queryChannelResult = chatDomain.useCases.queryChannels(data.filter1, null).execute()
+        val queryChannelResult = chatDomain.useCases.queryChannels(data.filter1, QuerySort()).execute()
         assertSuccess(queryChannelResult)
         val queryChannelsController = queryChannelResult.data()
         val channels = queryChannelsController.channels.getOrAwaitValue()

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/utils/TestDataHelper.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/utils/TestDataHelper.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.utils
 
+import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.events.ChannelDeletedEvent
 import io.getstream.chat.android.client.events.ChannelHiddenEvent
 import io.getstream.chat.android.client.events.ChannelTruncated
@@ -72,7 +73,7 @@ class TestDataHelper {
     val filter2 =
         Filters.and(Filters.eq("type", "livestream"), Filters.`in`("members", listOf(user1.id)))
 
-    val query1 = QueryChannelsEntity(filter1, null)
+    val query1 = QueryChannelsEntity(filter1, QuerySort())
 
     val attachment1 =
         Attachment(type = "image").apply { extraData = mutableMapOf("color" to "green") }

--- a/livedata/src/test/resources/junit-platform.properties
+++ b/livedata/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testinstance.lifecycle.default = per_class


### PR DESCRIPTION
`QuerySort` is an abailable parameter we use to sort the result query as the user expect, but It was only implemented for "remote queries", returning wrong result when some local data was stored on the device.
Because our queries are paginated, this paremeter needs to be added to our pagination class to apply the pagination on a proper way.
`QuerySort` was thought to be used on an API Request, where the name of the field is enough to perform the query. In local we have some problems, becasue this field is indicated as an String that indicate the name of the field where the sort should be done. To achieve this goal, I needed to use reflection ops over our model data to be able to obtain the proper fields and sort by them.
Because this name is an String, it could be whatever value, and we need to offer a default value where the field name doesn't exist on our model

Fix #21
Fix GetStream/stream-chat-android#582