### PR TITLE
Apply KtLint Plugin to Root of the Project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
     }
 }
 
+apply plugin: "org.jlleitschuh.gradle.ktlint"
 allprojects {
     repositories {
         google()


### PR DESCRIPTION
Apply KtLint Plugin to Root of the Project to add some extra gradle tasks like `ktlintApplyToIdea` that help us to apply Kotlin CheckStyle into our AndroidStudio configuration