### PR TITLE
Bugfix/message retry sort

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/dao/MessageDao.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/dao/MessageDao.kt
@@ -49,7 +49,7 @@ interface MessageDao {
 
     @Query(
         "SELECT * FROM stream_chat_message " +
-            "WHERE stream_chat_message.syncStatus IN (:syncStatus)"
+            "WHERE stream_chat_message.syncStatus IN (:syncStatus) ORDER BY createdAt ASC"
     )
     suspend fun selectSyncNeeded(syncStatus: SyncStatus = SyncStatus.SYNC_NEEDED): List<MessageEntity>
 }

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTest.kt
@@ -11,7 +11,6 @@ import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
 import io.getstream.chat.android.livedata.utils.calendar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -56,7 +55,7 @@ class MessageRepositoryTest : BaseDomainTest() {
     fun testSyncNeeded() = runBlocking(Dispatchers.IO) {
         val oldDate = calendar(2019, 11, 1)
         val message1 =
-            data.createMessage().apply { id="testSyncNeeded-1"; text = "yoyo"; syncStatus = SyncStatus.SYNC_NEEDED; createdAt =
+            data.createMessage().apply { id = "testSyncNeeded-1"; text = "yoyo"; syncStatus = SyncStatus.SYNC_NEEDED; createdAt =
                 oldDate }
         val message2 = data.createMessage()
             .apply { id = "testSyncNeeded-2"; text = "hi123"; syncStatus = SyncStatus.FAILED_PERMANENTLY }

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTest.kt
@@ -30,7 +30,6 @@ class MessageRepositoryTest : BaseDomainTest() {
     }
 
     @Test
-    @Ignore("LLC issues")
     fun testMessageObject() = runBlocking(Dispatchers.IO) {
         val messagea = Message(text = "hi").apply { reactionCounts = mutableMapOf("like" to 10) }
         val messageb = Message(text = "hi")
@@ -55,18 +54,25 @@ class MessageRepositoryTest : BaseDomainTest() {
 
     @Test
     fun testSyncNeeded() = runBlocking(Dispatchers.IO) {
+        val oldDate = calendar(2019, 11, 1)
         val message1 =
-            data.createMessage().apply { text = "yoyo"; syncStatus = SyncStatus.SYNC_NEEDED }
+            data.createMessage().apply { id="testSyncNeeded-1"; text = "yoyo"; syncStatus = SyncStatus.SYNC_NEEDED; createdAt =
+                oldDate }
         val message2 = data.createMessage()
-            .apply { id = "helloworld"; text = "hi123"; syncStatus = SyncStatus.FAILED_PERMANENTLY }
-        repo.insertMessages(listOf(message1, message2), true)
+            .apply { id = "testSyncNeeded-2"; text = "hi123"; syncStatus = SyncStatus.FAILED_PERMANENTLY }
+        val message3 = data.createMessage()
+            .apply { id = "testSyncNeeded-3"; text = "hi123"; syncStatus = SyncStatus.SYNC_NEEDED }
+        repo.insertMessages(listOf(message1, message2, message3), true)
 
         var messages = repo.selectSyncNeeded()
-        Truth.assertThat(messages.size).isEqualTo(1)
+
+        Truth.assertThat(messages.size).isEqualTo(2)
+        // verify that the old item is returned first
+        Truth.assertThat(messages.first().createdAt).isEqualTo(oldDate)
         Truth.assertThat(messages.first().syncStatus).isEqualTo(SyncStatus.SYNC_NEEDED)
 
         messages = repo.retryMessages()
-        Truth.assertThat(messages.size).isEqualTo(1)
+        Truth.assertThat(messages.size).isEqualTo(2)
         Truth.assertThat(messages.first().syncStatus).isEqualTo(SyncStatus.COMPLETED)
 
         messages = repo.selectSyncNeeded()

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTest.kt
@@ -55,8 +55,10 @@ class MessageRepositoryTest : BaseDomainTest() {
     fun testSyncNeeded() = runBlocking(Dispatchers.IO) {
         val oldDate = calendar(2019, 11, 1)
         val message1 =
-            data.createMessage().apply { id = "testSyncNeeded-1"; text = "yoyo"; syncStatus = SyncStatus.SYNC_NEEDED; createdAt =
-                oldDate }
+            data.createMessage().apply {
+                id = "testSyncNeeded-1"; text = "yoyo"; syncStatus = SyncStatus.SYNC_NEEDED
+                createdAt = oldDate
+            }
         val message2 = data.createMessage()
             .apply { id = "testSyncNeeded-2"; text = "hi123"; syncStatus = SyncStatus.FAILED_PERMANENTLY }
         val message3 = data.createMessage()


### PR DESCRIPTION
1. update the test to fail if we return message in the wrong order
2. add the "ORDER BY" in the query

Fixes: https://github.com/GetStream/stream-chat-android-livedata/issues/31