### PR TITLE
[cas-217] Fix command support

### DIFF
--- a/livedata/build.gradle
+++ b/livedata/build.gradle
@@ -150,7 +150,7 @@ afterEvaluate {
                 // Custom attributes of the publication
                 groupId = project.group
                 artifactId = 'stream-chat-android-livedata'
-                version = '0.6.10-SNAPSHOT'
+                version = '0.7.0-SNAPSHOT'
             }
         }
     }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -270,9 +270,9 @@ class ChatDomainImpl private constructor(
         return database
     }
 
-    suspend fun runAndRetry(runnable: () -> Call<*>): Result<*> {
+    suspend fun <T> runAndRetry(runnable: () -> Call<T>): Result<T> {
         var attempt = 1
-        var result: Result<*>
+        var result: Result<T>
 
         while (true) {
             result = runnable().execute()

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -372,7 +372,6 @@ class ChannelControllerImpl(
      */
 
     suspend fun sendMessage(message: Message): Result<Message> = withContext(scope.coroutineContext) {
-        var output: Result<Message>
         val online = domainImpl.isOnline()
 
         // set defaults for id, cid and created at
@@ -405,20 +404,21 @@ class ChannelControllerImpl(
             domainImpl.repos.channels.insert(it)
         }
 
-        if (online) {
+        return@withContext if (online) {
             logger.logI("Starting to send message with id ${message.id} and text ${message.text}")
 
-            val runnable = {
-                val result = channelController.sendMessage(message)
-                result
-            }
-            val result = domainImpl.runAndRetry(runnable)
+            val result = domainImpl.runAndRetry { channelController.sendMessage(message) }
             if (result.isSuccess) {
-                // set sendMessageCompletedAt so we know when to edit vs call sendMessage
-                messageEntity.syncStatus = SyncStatus.COMPLETED
-                messageEntity.sendMessageCompletedAt = Date()
-                domainImpl.repos.messages.insert(messageEntity)
-                output = Result(result.data() as Message?, null)
+                val processedMessage: Message = result.data()
+                processedMessage.apply {
+                    syncStatus = SyncStatus.COMPLETED
+                    val entity = MessageEntity(this)
+                    entity.sendMessageCompletedAt = Date()
+                    domainImpl.repos.messages.insert(entity)
+                }
+
+                upsertMessage(processedMessage)
+                Result(processedMessage, null)
             } else {
                 if (result.error().isPermanent()) {
                     messageEntity.syncStatus = SyncStatus.FAILED_PERMANENTLY
@@ -426,14 +426,12 @@ class ChannelControllerImpl(
                     messageEntity.syncStatus = SyncStatus.SYNC_NEEDED
                 }
                 domainImpl.repos.messages.insert(messageEntity)
-                output = Result(null, result.error())
+                Result(message, result.error())
             }
         } else {
             logger.logI("Chat is offline, postponing send message with id ${message.id} and text ${message.text}")
-            output = Result(message, null)
+            Result(message, null)
         }
-
-        output
     }
 
     suspend fun sendImage(file: File): Result<String> = withContext(scope.coroutineContext) {
@@ -482,7 +480,7 @@ class ChannelControllerImpl(
             if (result.isSuccess) {
                 reaction.syncStatus = SyncStatus.COMPLETED
                 domainImpl.repos.reactions.insertReaction(reaction)
-                return Result(result.data() as Reaction, null)
+                return Result(result.data(), null)
             } else {
                 if (result.error().isPermanent()) {
                     reaction.syncStatus = SyncStatus.FAILED_PERMANENTLY
@@ -529,7 +527,7 @@ class ChannelControllerImpl(
             if (result.isSuccess) {
                 reaction.syncStatus = SyncStatus.COMPLETED
                 domainImpl.repos.reactions.insertReaction(reaction)
-                return Result(result.data() as Message, null)
+                return Result(result.data(), null)
             } else {
                 if (result.error().isPermanent()) {
                     reaction.syncStatus = SyncStatus.FAILED_PERMANENTLY
@@ -905,7 +903,7 @@ class ChannelControllerImpl(
                 upsertMessage(message)
                 domainImpl.repos.messages.insertMessage(message)
 
-                return Result(result.data() as Message, null)
+                return Result(result.data(), null)
             } else {
                 if (result.error().isPermanent()) {
                     message.syncStatus = SyncStatus.FAILED_PERMANENTLY
@@ -944,7 +942,7 @@ class ChannelControllerImpl(
                 message.syncStatus = SyncStatus.COMPLETED
                 upsertMessage(message)
                 domainImpl.repos.messages.insertMessage(message)
-                return Result(result.data() as Message, null)
+                return Result(result.data(), null)
             } else {
                 if (result.error().isPermanent()) {
                     message.syncStatus = SyncStatus.FAILED_PERMANENTLY

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageImpl.kt
@@ -29,9 +29,6 @@ class SendMessageImpl(var domainImpl: ChatDomainImpl) : SendMessage {
             channelRepo.sendMessage(message)
         }
 
-        return CallImpl2<Message>(
-            runnable,
-            channelRepo.scope
-        )
+        return CallImpl2(runnable, channelRepo.scope)
     }
 }


### PR DESCRIPTION
* Make the `runAndRetry()` function type-safe
* Update the message in storage with the one processed by the backend 
* Emmit a backend-processed message event to channel once "send message" operation was successful 
Without ☝🏼  the giphy picker couldn't be rendered because the emitted message didn't contain `type="ephemeral"` and `command="giphy"` values which are being set by the backend.