### PR TITLE
Fix/cas 188 remove duplicates of new channels

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -199,9 +199,9 @@ class QueryChannelsControllerImpl(
     private fun addChannels(newChannels: List<Channel>, onTop: Boolean = false) {
         // second page adds to the list of channels
         queryEntity.channelCids = if (onTop) {
-            newChannels.map { it.cid } + queryEntity.channelCids
+            (newChannels.map { it.cid } + queryEntity.channelCids).distinct()
         } else {
-            queryEntity.channelCids + newChannels.map { it.cid }
+            (queryEntity.channelCids + newChannels.map { it.cid }).distinct()
         }
 
         _channels.postValue(

--- a/livedata/src/test/java/androidx/arch/core/executor/testing/InstantExecutorExtension.kt
+++ b/livedata/src/test/java/androidx/arch/core/executor/testing/InstantExecutorExtension.kt
@@ -1,0 +1,25 @@
+package androidx.arch.core.executor.testing
+
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.arch.core.executor.TaskExecutor
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class InstantExecutorExtension : BeforeEachCallback, AfterEachCallback {
+
+    override fun beforeEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance()
+            .setDelegate(object : TaskExecutor() {
+                override fun executeOnDiskIO(runnable: Runnable) = runnable.run()
+
+                override fun postToMainThread(runnable: Runnable) = runnable.run()
+
+                override fun isMainThread(): Boolean = true
+            })
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(null)
+    }
+}

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImplTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.*
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.livedata.ChatDomainImpl
+import io.getstream.chat.android.livedata.randomChannel
 import io.getstream.chat.android.livedata.utils.getOrAwaitValue
 import kotlinx.coroutines.Job
 import org.amshove.kluent.shouldBeEqualTo
@@ -20,7 +21,7 @@ internal class QueryChannelsControllerImplTest {
             .givenNewChannelController(channelController)
             .setupChatControllersInstantiation()
             .get()
-        val newChannel = Channel(cid = "CID", id = "ID")
+        val newChannel = randomChannel()
 
         sut.addChannelIfFilterMatches(newChannel)
 
@@ -33,7 +34,7 @@ internal class QueryChannelsControllerImplTest {
             .givenNewChannelController(mock())
             .setupChatControllersInstantiation()
             .get()
-        val newChannel = Channel(cid = "ChannelType:ChannelID", id = "ChannelID")
+        val newChannel = randomChannel(cid = "ChannelType:ChannelID")
 
         sut.addChannelIfFilterMatches(newChannel)
 
@@ -48,7 +49,7 @@ internal class QueryChannelsControllerImplTest {
             .givenNewChannelController(mock())
             .setupChatControllersInstantiation()
             .get()
-        val newChannel = Channel(cid = "ChannelType:ChannelID", id = "ChannelID")
+        val newChannel = randomChannel(cid = "ChannelType:ChannelID")
 
         sut.addChannelIfFilterMatches(newChannel)
         sut.addChannelIfFilterMatches(newChannel)

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImplTest.kt
@@ -59,7 +59,7 @@ internal class QueryChannelsControllerImplTest {
     }
 }
 
-class Fixture {
+private class Fixture {
     private val chatClient: ChatClient = mock()
     private val chatDomainImpl: ChatDomainImpl = mock()
 

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImplTest.kt
@@ -1,0 +1,89 @@
+package io.getstream.chat.android.livedata.controller
+
+import androidx.arch.core.executor.testing.InstantExecutorExtension
+import com.nhaarman.mockitokotlin2.*
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.livedata.ChatDomainImpl
+import io.getstream.chat.android.livedata.utils.getOrAwaitValue
+import kotlinx.coroutines.Job
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(InstantExecutorExtension::class)
+internal class QueryChannelsControllerImplTest {
+    @Test
+    fun `when add channel if filter matches should update LiveData from channel to channel controller`() {
+        val chatDomainImpl = mock<ChatDomainImpl>().apply {
+            whenever(currentUser) doReturn mock()
+            whenever(job) doReturn Job()
+        }
+        val channelController = spy(ChannelControllerImpl("ChannelType", "CID", mock(), chatDomainImpl))
+        val sut = Fixture()
+            .givenChatDomain(chatDomainImpl)
+            .giveNewChannelController(channelController)
+            .setupChantControllersInstantiation()
+            .get()
+        val newChannel = Channel(cid = "CID", id = "ID")
+
+        sut.addChannelIfFilterMatches(newChannel)
+
+        verify(channelController).updateLiveDataFromChannel(eq(newChannel))
+    }
+
+    @Test
+    fun `when add channel if filter matches should post value to liveData with the same channel ID`() {
+        val chatDomainImpl = mock<ChatDomainImpl>().apply {
+            whenever(currentUser) doReturn mock()
+            whenever(job) doReturn Job()
+        }
+        val channelController = spy(ChannelControllerImpl("ChannelType", "ChannelID", mock(), chatDomainImpl))
+        val sut = Fixture()
+            .givenChatDomain(chatDomainImpl)
+            .giveNewChannelController(channelController)
+            .setupChantControllersInstantiation()
+            .get()
+        val newChannel = Channel(cid = "ChannelType:ChannelID", id = "ChannelID")
+
+        sut.addChannelIfFilterMatches(newChannel)
+
+        val result = sut.channels.getOrAwaitValue()
+        result.size shouldBeEqualTo 1
+        result.first().cid shouldBeEqualTo "ChannelType:ChannelID"
+    }
+}
+
+class Fixture {
+    private val chatClient: ChatClient = mock()
+    private var chatDomainImpl: ChatDomainImpl? = null
+
+    fun givenChatDomain(chatDomainImpl: ChatDomainImpl): Fixture {
+        this.chatDomainImpl = chatDomainImpl
+        return this
+    }
+
+    fun giveNewChannelController(channelControllerImpl: ChannelControllerImpl): Fixture {
+        whenever(chatDomainImpl?.channel(any<Channel>())) doReturn channelControllerImpl
+        return this
+    }
+
+    fun setupChantControllersInstantiation(): Fixture {
+        whenever(chatDomainImpl?.channel(any<String>())) doAnswer { invocation ->
+            val cid = invocation.arguments[0] as String
+            val parts = cid.split(":")
+            ChannelControllerImpl(
+                parts[0],
+                parts[1],
+                mock(),
+                chatDomainImpl.shouldNotBeNull()
+            )
+        }
+        whenever(chatDomainImpl.shouldNotBeNull().getChannelConfig(any())) doReturn mock()
+        return this
+    }
+
+    fun get(): QueryChannelsControllerImpl =
+        QueryChannelsControllerImpl(mock(), mock(), chatClient, chatDomainImpl.shouldNotBeNull())
+}


### PR DESCRIPTION
When create a new channel it doubled in the channel list view. It happened because we didn't check duplicates of channels in QueryChannelsControllerImpl. The fix is very easy.
I added test for addChannel case.
When I was writing test I found that this class is coupled with concrete classes not interfaces, code is too coupled. Good point for refactoring