### PR TITLE
Fix unexpected crash when creator of channel was not set

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
@@ -99,8 +99,7 @@ data class ChannelEntity(var type: String, var channelId: String) {
 
         c.read = reads.values.map { it.toChannelUserRead(userMap) }
 
-        c.createdBy = userMap[createdByUserId]
-            ?: error("userMap doesnt contain the user $createdByUserId for the channel.created_by channel $cid")
+        c.createdBy = userMap[createdByUserId]?: User()
 
         return c
     }


### PR DESCRIPTION
Since we let use empty constructors for channels we can't guarantee that any field must be not null