### PR TITLE
[cas-242] Fix background data sync condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # To be released:
+- Stop trying to execute background sync in case ChatDomain.offlineEnabled is set to false
 
 # Sep 15th, 2020 - 0.7.5
 - Fix offline support for adding and removing reactions

--- a/livedata/src/main/AndroidManifest.xml
+++ b/livedata/src/main/AndroidManifest.xml
@@ -3,6 +3,6 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <application>
-        <service android:name=".service.sync.SyncService"/>
+        <service android:name=".service.sync.OfflineSyncFirebaseMessagingService"/>
     </application>
 </manifest>

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/service/sync/OfflineSyncFirebaseMessagingService.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/service/sync/OfflineSyncFirebaseMessagingService.kt
@@ -59,20 +59,23 @@ class OfflineSyncFirebaseMessagingService : FirebaseMessagingService() {
         GlobalScope.launch(Dispatchers.IO) {
             try {
                 performSync(ChatDomain.instance(), cid)
-                ChatClient.instance().onMessageReceived(message, this@OfflineSyncFirebaseMessagingService)
+                ChatClient.instance()
+                    .onMessageReceived(message, this@OfflineSyncFirebaseMessagingService)
             } catch (e: UninitializedPropertyAccessException) {
                 val syncConfig = syncModule.encryptedBackgroundSyncConfigStore.get()
-                val user = User(id = syncConfig.userId)
-                val client = initClient(
-                    this@OfflineSyncFirebaseMessagingService,
-                    user,
-                    syncConfig.userToken,
-                    syncConfig.apiKey
-                )
                 if (BackgroundSyncConfig.UNAVAILABLE != syncConfig) {
-                    val domain = initDomain(user, client)
-                    performSync(domain, cid)
-                    client.onMessageReceived(message, this@OfflineSyncFirebaseMessagingService)
+                    val user = User(id = syncConfig.userId)
+                    val client = initClient(
+                        this@OfflineSyncFirebaseMessagingService,
+                        user,
+                        syncConfig.userToken,
+                        syncConfig.apiKey
+                    )
+                    if (BackgroundSyncConfig.UNAVAILABLE != syncConfig) {
+                        val domain = initDomain(user, client)
+                        performSync(domain, cid)
+                        client.onMessageReceived(message, this@OfflineSyncFirebaseMessagingService)
+                    }
                 }
             } finally {
                 stopForeground(true)


### PR DESCRIPTION
Stop trying to execute background data sync if offline support is not enabled in `ChatDomain.Builder`. In this case, apikey is not stored.