### PR TITLE
Add posting empty channels map when queryChannels fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # To be released:
 - Fix crash when map channels DB entity to Channel
+- Add posting empty channels map when queryChannels fails either offline and online which prevents infinite loader
 
 # Sep 18th, 2020 - 0.7.6
 - Store needed users in DB

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -194,6 +194,9 @@ class QueryChannelsControllerImpl(
             recoveryNeeded = true
             output = Result(channels, null)
         }
+        if (!output.isSuccess) {
+            _channels.postValue(emptyMap())
+        }
         loader.postValue(false)
         return output
     }


### PR DESCRIPTION
We didn't update channels LiveData when we haven't any channels stored in our database and for some reason (e.g. we were offline) we didn't call queryChannelsOnline. In that case mentioned LiveData wasn't updated and we had an infinite loader when fetching channels.