### PR TITLE
[CAS-261] Fix channels query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # To be released:
 - Handle the new `ChannelUpdatedByUserEvent` 
 - Update client to 1.16.1: See changes: https://github.com/GetStream/stream-chat-android-client/releases/tag/1.16.1
+- Improve online status handling
+- Replace posting an empty channels map when the channels query wasn't run online and offline storage is empty with error
 
 # Sep 23rd, 2020 - 0.8.0
 

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -152,6 +152,8 @@ class ChatDomainImpl private constructor(
     internal var syncState: SyncStateEntity? = null
     internal lateinit var initJob: Deferred<SyncStateEntity?>
 
+    private var isOnline = false
+
     /** The retry policy for retrying failed requests */
     override var retryPolicy: RetryPolicy =
         DefaultRetryPolicy()
@@ -427,30 +429,29 @@ class ChatDomainImpl private constructor(
         return currentUser.id + "-" + UUID.randomUUID().toString()
     }
 
-    fun setOffline() {
+    internal fun setOffline() {
+        isOnline = false
         _online.value = false
     }
 
-    fun postOffline() {
+    internal fun postOffline() {
+        isOnline = false
         _online.postValue(false)
     }
 
-    fun setOnline() {
+    internal fun setOnline() {
+        isOnline = true
         _online.value = true
     }
 
-    fun postOnline() {
+    internal fun postOnline() {
+        isOnline = true
         _online.postValue(true)
     }
 
-    override fun isOnline(): Boolean {
-        val online = _online.value!!
-        return online
-    }
+    override fun isOnline(): Boolean = isOnline
 
-    override fun isOffline(): Boolean {
-        return !_online.value!!
-    }
+    override fun isOffline(): Boolean  = !isOnline
 
     override fun isInitialized(): Boolean {
         return _initialized.value ?: false

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -451,7 +451,7 @@ class ChatDomainImpl private constructor(
 
     override fun isOnline(): Boolean = isOnline
 
-    override fun isOffline(): Boolean  = !isOnline
+    override fun isOffline(): Boolean = !isOnline
 
     override fun isInitialized(): Boolean {
         return _initialized.value ?: false

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -192,10 +192,7 @@ class QueryChannelsControllerImpl(
             output = result
         } else {
             recoveryNeeded = true
-            output = Result(channels, null)
-        }
-        if (!output.isSuccess) {
-            _channels.postValue(emptyMap())
+            output = channels?.let { Result(it) } ?: Result(error = ChatError(message = "Channels Query wasn't run online and the offline storage is empty"))
         }
         loader.postValue(false)
         return output


### PR DESCRIPTION
Infinite channels loading was caused by delays in posting online status using LiveData. The problem was that `ConnectedEvent` (which changes online status and reruns some queries if needed) is received almost at the same time as we call `queryChannels` and that leads to a situation when recovery was called just before running `queryChannels` for the first time and on the other hand, the first `queryChannels` call was done before "onlineStatusLiveData" was updated (so it was run only offline at because it was the first channels query - the offline storage was empty). 
Moreover, I've replaced posting an empty channels map when the query wasn't run online and offline storage is empty with error - this fixes an issue when the channel list shows up as empty, and then suddenly shows some channels 
