### PR TITLE
Request for members by default when querying  channels

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -53,6 +53,10 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.set
 
 private val CHANNEL_CID_REGEX = Regex("^!?[\\w-]+:!?[\\w-]+$")
+private const val MESSAGE_LIMIT = 30
+private const val MEMBER_LIMIT = 30
+private const val INITIAL_CHANNEL_OFFSET = 0
+private const val CHANNEL_LIMIT = 30
 
 /**
  * The Chat Repository exposes livedata objects to make it easier to build your chat UI.
@@ -520,7 +524,7 @@ class ChatDomainImpl private constructor(
         val updatedChannelIds = mutableSetOf<String>()
         val queriesToRetry = activeQueryMapImpl.values.toList().filter { it.recoveryNeeded || recoveryNeeded }.take(3)
         for (queryRepo in queriesToRetry) {
-            val response = queryRepo.runQueryOnline(QueryChannelsPaginationRequest(QuerySort(), 0, 30, 30))
+            val response = queryRepo.runQueryOnline(QueryChannelsPaginationRequest(QuerySort(), INITIAL_CHANNEL_OFFSET, CHANNEL_LIMIT, MESSAGE_LIMIT, MEMBER_LIMIT))
             if (response.isSuccess) {
                 updatedChannelIds.addAll(response.data().map { it.cid })
             }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/request/Mapper.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/request/Mapper.kt
@@ -12,9 +12,7 @@ internal fun QueryChannelsPaginationRequest.toAnyChannelPaginationRequest(): Any
     }
 
 internal fun QueryChannelsPaginationRequest.toQueryChannelsRequest(filter: FilterObject, userPresence: Boolean): QueryChannelsRequest {
-    var request = QueryChannelsRequest(filter, channelOffset, channelLimit, sort)
-
-    request = request.withMessages(messageLimit)
+    var request = QueryChannelsRequest(filter, channelOffset, channelLimit, sort, messageLimit, memberLimit)
     if (userPresence) {
         request = request.withPresence()
     }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/request/QueryChannelsPaginationRequest.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/request/QueryChannelsPaginationRequest.kt
@@ -6,7 +6,8 @@ data class QueryChannelsPaginationRequest(
     val sort: QuerySort,
     val channelOffset: Int = 0,
     val channelLimit: Int = 30,
-    val messageLimit: Int = 10
+    val messageLimit: Int = 10,
+    val memberLimit: Int
 ) {
 
     val isFirstPage: Boolean

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerTest.kt
@@ -20,7 +20,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun newChannelAdded() = runBlocking(Dispatchers.IO) {
-        val request = QueryChannelsPaginationRequest(QuerySort())
+        val request = QueryChannelsPaginationRequest(QuerySort(), 0, 30, 10, 0)
         queryControllerImpl.runQuery(request)
         var channels = queryControllerImpl.channels.getOrAwaitValue()
         val oldSize = channels.size
@@ -36,7 +36,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun newChannelFiltered() = runBlocking(Dispatchers.IO) {
-        val request = QueryChannelsPaginationRequest(QuerySort())
+        val request = QueryChannelsPaginationRequest(QuerySort(), 0, 30, 10, 0)
         val queryChannelsController = chatDomainImpl.queryChannels(data.filter2, QuerySort())
         queryChannelsController.newChannelEventFilter = { channel: Channel, filterObject: FilterObject ->
             // ignore everything
@@ -56,12 +56,12 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
     @Test
     @Ignore("mock me")
     fun testLoadMore() = runBlocking(Dispatchers.IO) {
-        val paginate = QueryChannelsPaginationRequest(QuerySort(), 0, 2)
+        val paginate = QueryChannelsPaginationRequest(QuerySort(), 0, 2, 10, 0)
         val result = queryControllerImpl.runQuery(paginate)
         assertSuccess(result)
         var channels = queryControllerImpl.channels.getOrAwaitValue()
         Truth.assertThat(channels.size).isEqualTo(2)
-        val request = queryControllerImpl.loadMoreRequest(1)
+        val request = queryControllerImpl.loadMoreRequest(1, 10, 0)
         Truth.assertThat(request.channelOffset).isEqualTo(2)
         val result2 = queryControllerImpl.runQuery(request)
         assertSuccess(result2)
@@ -78,7 +78,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
         chatDomainImpl.repos.messages.insertMessage(data.message1)
         chatDomainImpl.storeStateForChannel(data.channel1)
         chatDomainImpl.setOffline()
-        val channels = queryControllerImpl.runQueryOffline(QueryChannelsPaginationRequest(query.sort, 0, 2))
+        val channels = queryControllerImpl.runQueryOffline(QueryChannelsPaginationRequest(query.sort, 0, 2, 10, 0))
         // should return 1 since only 1 is stored in offline storage
         Truth.assertThat(channels?.size).isEqualTo(1)
         // verify we load messages correctly
@@ -93,7 +93,7 @@ class QueryChannelsControllerTest : BaseConnectedIntegrationTest() {
         chatDomainImpl.repos.queryChannels.insert(query)
         chatDomainImpl.storeStateForChannel(data.channel1)
         chatDomainImpl.setOffline()
-        queryControllerImpl.runQuery(QueryChannelsPaginationRequest(query.sort, 0, 2))
+        queryControllerImpl.runQuery(QueryChannelsPaginationRequest(query.sort, 0, 2, 10, 0))
         val channels = queryControllerImpl.channels.getOrAwaitValue()
         // should return 1 since only 1 is stored in offline storage
         Truth.assertThat(channels.size).isEqualTo(1)

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
@@ -42,7 +42,7 @@ class HideChannelImplTest : BaseConnectedIntegrationTest() {
         // setup the query channel controller
         chatDomain.useCases.queryChannels(data.filter1, QuerySort(), 0, 10).execute()
         var queryChannelsControllerImpl = chatDomainImpl.queryChannels(data.filter1, QuerySort())
-        queryChannelsControllerImpl.runQueryOffline(QueryChannelsPaginationRequest(QuerySort()))
+        queryChannelsControllerImpl.runQueryOffline(QueryChannelsPaginationRequest(QuerySort(), 0, 30, 10, 0))
 
         // verify we have 1 channel in the result list and that it's hidden
         val channelController = chatDomainImpl.channel(data.channel1)


### PR DESCRIPTION
Members weren't requested by default when asking for channels, so the members list obtained was empty. It is an issue for DM Channels where the picture rendered on the channels list is the picture of the other user. Happend the same with the Channel Name. 

Fixes https://github.com/GetStream/stream-chat-android/issues/644