### PR TITLE
Handle not found members into our DB

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
@@ -95,7 +95,7 @@ data class ChannelEntity(var type: String, var channelId: String) {
         c.lastMessageAt = lastMessageAt
         c.syncStatus = syncStatus
 
-        c.members = members.values.map { it.toMember(userMap) }
+        c.members = members.values.mapNotNull { it.toMember(userMap) }
 
         c.read = reads.values.map { it.toChannelUserRead(userMap) }
 

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/MemberEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/MemberEntity.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.entity
 
+import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.User
 import java.util.Date
@@ -36,15 +37,8 @@ data class MemberEntity(var userId: String) {
     }
 
     /** converts a member entity into a member */
-    fun toMember(userMap: Map<String, User>): Member {
-        val user = userMap[userId] ?: error("userMap is missing the user for this member")
-        val r = Member(user, role)
-        r.createdAt = createdAt
-        r.updatedAt = updatedAt
-        r.isInvited = isInvited
-        r.inviteAcceptedAt = inviteAcceptedAt
-        r.inviteRejectedAt = inviteRejectedAt
-
-        return r
-    }
+    fun toMember(userMap: Map<String, User>): Member? =
+        userMap[userId]?.let {
+            Member(it, role, createdAt, updatedAt, isInvited, inviteAcceptedAt, inviteRejectedAt)
+        } ?: null.also { ChatLogger.get("MemberEntity").logE("userMap is missing the user with id='$userId` needed to create this member") }
 }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/MemberEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/MemberEntity.kt
@@ -37,8 +37,13 @@ data class MemberEntity(var userId: String) {
     }
 
     /** converts a member entity into a member */
-    fun toMember(userMap: Map<String, User>): Member? =
-        userMap[userId]?.let {
-            Member(it, role, createdAt, updatedAt, isInvited, inviteAcceptedAt, inviteRejectedAt)
-        } ?: null.also { ChatLogger.get("MemberEntity").logE("userMap is missing the user with id='$userId` needed to create this member") }
+    fun toMember(userMap: Map<String, User>): Member? {
+        val user = userMap[userId]
+        if (user == null) {
+            ChatLogger.get("MemberEntity")
+                .logE("userMap is missing the user with id='$userId` needed to create this member")
+            return null
+        }
+        return Member(user, role, createdAt, updatedAt, isInvited, inviteAcceptedAt, inviteRejectedAt)
+    }
 }


### PR DESCRIPTION
### Description

By some reason we are not storing all members of a channels into our DB, and when we ask for members of a channel it is crashing.
This part is going to be refactored by @ogkuzmin into another task, but for now we can avoid this NPE by omitting this member

### Checklist

- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
