### PR TITLE
Fix/event handler npe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # To be released:
 - Update LLC to version 1.16.6
 - Use `createdLocallyAt` and `updatedLocallyAt` properties in ChannelController and ThreadController
-
 - Add setting attachment data even if attachment upload failed
+- Fix NPE while ChatEvent was handled
 
 # Oct 7th, 2020 - 0.8.4
 - Update client to 1.16.5: See changes: https://github.com/GetStream/stream-chat-android-client/releases/tag/1.16.5

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -211,18 +211,6 @@ class EventHandlerImpl(
                         hidden = false
                     }
                 }
-                is ChannelUserBannedEvent -> {
-                    users[event.user.id] = event.user
-                }
-                is GlobalUserBannedEvent -> {
-                    users[event.user.id] = event.user.apply { banned = true }
-                }
-                is ChannelUserUnbannedEvent -> {
-                    users[event.user.id] = event.user
-                }
-                is GlobalUserUnbannedEvent -> {
-                    users[event.user.id] = event.user.apply { banned = false }
-                }
                 is NotificationMutesUpdatedEvent -> {
                     domainImpl.updateCurrentUser(event.me)
                 }
@@ -231,15 +219,11 @@ class EventHandlerImpl(
                 }
                 is MessageReadEvent -> {
                     // get the channel, update reads, write the channel
-                    users[event.user.id] = event.user
                     channelMap[event.cid]?.let {
                         channels[it.cid] = it.apply {
                             updateReads(ChannelUserRead(user = event.user, lastRead = event.createdAt))
                         }
                     }
-                }
-                is UserUpdatedEvent -> {
-                    users[event.user.id] = event.user
                 }
                 is ReactionNewEvent -> {
                     // get the message, update the reaction data, update the message
@@ -346,43 +330,40 @@ class EventHandlerImpl(
                 }
                 is NotificationMarkReadEvent -> {
                     event.totalUnreadCount?.let { domainImpl.setTotalUnreadCount(it) }
-                    users[event.user.id] = event.user
                     channelMap[event.cid]?.let {
                         channels[it.cid] = it.apply {
                             updateReads(ChannelUserRead(user = event.user, lastRead = event.createdAt))
                         }
                     }
                 }
-                is UserDeletedEvent -> {
-                    users[event.user.id] = event.user
-                }
                 is UserMutedEvent -> {
                     users[event.targetUser.id] = event.targetUser
-                    users[event.user.id] = event.user
                 }
                 is UsersMutedEvent -> {
                     event.targetUsers.forEach { users[it.id] = it }
-                    users[event.user.id] = event.user
-                }
-                is UserPresenceChangedEvent -> {
-                    users[event.user.id] = event.user
-                }
-                is UserStartWatchingEvent -> {
-                    users[event.user.id] = event.user
-                }
-                is UserStopWatchingEvent -> {
-                    users[event.user.id] = event.user
                 }
                 is UserUnmutedEvent -> {
-                    users[event.user.id] = event.user
                     users[event.targetUser.id] = event.targetUser
                 }
                 is UsersUnmutedEvent -> {
                     event.targetUsers.forEach { users[it.id] = it }
-                    users[event.user.id] = event.user
                 }
-                is TypingStartEvent, is TypingStopEvent, is HealthEvent, is ConnectingEvent, is DisconnectedEvent,
-                is ErrorEvent, is UnknownEvent -> Unit
+                is TypingStartEvent,
+                is TypingStopEvent,
+                is HealthEvent,
+                is ConnectingEvent,
+                is DisconnectedEvent,
+                is ErrorEvent,
+                is UnknownEvent,
+                is ChannelUserBannedEvent,
+                is GlobalUserBannedEvent,
+                is ChannelUserUnbannedEvent,
+                is GlobalUserUnbannedEvent,
+                is UserUpdatedEvent,
+                is UserDeletedEvent,
+                is UserPresenceChangedEvent,
+                is UserStartWatchingEvent,
+                is UserStopWatchingEvent -> Unit
             }.exhaustive
         }
         // actually insert the data

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -100,6 +100,7 @@ class EventHandlerImpl(
         // inject a null instance into property `user` that doesn't allow null values.
         // This is a workaround, while we identify which event type is, that omit null values without
         // break our public API
+        @Suppress("USELESS_CAST")
         users += events.filterIsInstance<UserEvent>().mapNotNull { it.user as User? }.associateBy(User::id)
 
         // step 1. see which data we need to retrieve from offline storage


### PR DESCRIPTION
### Description
For some reason backend is not sending us the user instance into some events that they should and we are not able to identify which event type is. Gson, because it is using reflection, inject a null instance into property `user` that doesn't allow null values. This is a workaround, while we identify which event type is, that omit null values without break our public API

### Checklist

- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added

Fix https://github.com/GetStream/stream-chat-android/issues/685