### PR TITLE
Feature/items

### DIFF
--- a/livedata/build.gradle
+++ b/livedata/build.gradle
@@ -90,7 +90,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0-beta01"
     implementation "androidx.security:security-crypto:1.1.0-alpha02"
 
-    testImplementation 'androidx.benchmark:benchmark-junit4:1.0.0'
     testImplementation "androidx.room:room-testing:$room_version"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "io.github.cdimascio:java-dotenv:5.1.4"

--- a/livedata/build.gradle
+++ b/livedata/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 
     api "com.github.getstream:stream-chat-android-client:1.16.6"
 
+
     def room_version = "2.2.5"
     def work_version = "2.4.0"
     def jupiter_version = "5.6.2"
@@ -89,6 +90,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.0-beta01"
     implementation "androidx.security:security-crypto:1.1.0-alpha02"
 
+    testImplementation 'androidx.benchmark:benchmark-junit4:1.0.0'
     testImplementation "androidx.room:room-testing:$room_version"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "io.github.cdimascio:java-dotenv:5.1.4"
@@ -98,7 +100,7 @@ dependencies {
     testImplementation "androidx.test.ext:junit:1.1.2"
     testImplementation "androidx.test.ext:junit-ktx:1.1.2"
     testImplementation "androidx.test:core-ktx:1.3.0"
-    testImplementation "org.robolectric:robolectric:4.3.1"
+    testImplementation "org.robolectric:robolectric:4.4"
     testImplementation "org.mockito:mockito-core:3.4.6"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "org.amshove.kluent:kluent:1.61"

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
@@ -11,6 +11,7 @@ import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.entity.ChannelEntityPair
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
+import java.util.Date
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
 
@@ -22,6 +23,10 @@ internal fun Channel.users(): List<User> = members.map(Member::user) +
     read.map(ChannelUserRead::user) +
     createdBy +
     messages.flatMap { it.users() }
+
+fun Message.getCreatedAtOrThrow(): Date {
+    return checkNotNull<Date>(createdAt ?: createdLocallyAt) { "It's required to set a createdAt or createdLocallyAt value for messages" }
+}
 
 internal fun Message.addReaction(reaction: Reaction, isMine: Boolean) {
 

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItem.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItem.kt
@@ -7,6 +7,14 @@ import java.util.Date
 import java.util.zip.CRC32
 import java.util.zip.Checksum
 
+/**
+ * MessageListItem is a sealed class with everything that is typically displayed in a message list
+ * - DateSeparatorItem
+ * - MessageItem
+ * - TypingItem
+ * - ThreadSeparatorItem
+ * - ReadStateItem
+ */
 sealed class MessageListItem {
 
     fun getStableId(): Long {
@@ -16,6 +24,7 @@ sealed class MessageListItem {
             is ThreadSeparatorItem -> "id_thread_separator"
             is MessageItem -> message.id
             is DateSeparatorItem -> date.toString()
+            is ReadStateItem -> "read_" + reads.map { it.user.id }.joinToString { "," }
         }
         checksum.update(plaintext.toByteArray(), 0, plaintext.toByteArray().size)
         return checksum.value
@@ -30,10 +39,18 @@ sealed class MessageListItem {
         val positions: List<Position> = listOf(),
         val isMine: Boolean = false,
         val messageReadBy: List<ChannelUserRead> = listOf()
-    ) : MessageListItem()
+    ) : MessageListItem() {
+        fun isTheirs(): Boolean {
+            return !isMine
+        }
+    }
 
     data class TypingItem @JvmOverloads constructor(
         val users: List<User>,
+    ) : MessageListItem()
+
+    data class ReadStateItem @JvmOverloads constructor(
+        val reads: List<ChannelUserRead>,
     ) : MessageListItem()
 
     data class ThreadSeparatorItem @JvmOverloads constructor(

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItem.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItem.kt
@@ -1,0 +1,56 @@
+package io.getstream.chat.android.livedata.utils
+
+import io.getstream.chat.android.client.models.ChannelUserRead
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
+import java.util.Date
+import java.util.zip.CRC32
+import java.util.zip.Checksum
+
+sealed class MessageListItem {
+    abstract val isMine: Boolean
+    abstract val messageReadBy: MutableList<ChannelUserRead>
+
+    fun getStableId(): Long {
+        val checksum: Checksum = CRC32()
+        val plaintext = when (this) {
+            is TypingItem -> "id_typing"
+            is ThreadSeparatorItem -> "id_thread_separator"
+            is MessageItem -> message.id
+            is DateSeparatorItem -> date.toString()
+        }
+        checksum.update(plaintext.toByteArray(), 0, plaintext.toByteArray().size)
+        return checksum.value
+    }
+
+    data class DateSeparatorItem @JvmOverloads constructor(
+        val date: Date,
+        override val isMine: Boolean = false,
+        override val messageReadBy: MutableList<ChannelUserRead> = mutableListOf()
+    ) : MessageListItem()
+
+    data class MessageItem @JvmOverloads constructor(
+        val message: Message,
+        val positions: List<Position> = listOf(),
+        override val isMine: Boolean = false,
+        override val messageReadBy: MutableList<ChannelUserRead> = mutableListOf()
+    ) : MessageListItem()
+
+    data class TypingItem @JvmOverloads constructor(
+        val users: List<User>,
+        override val isMine: Boolean = false,
+        override val messageReadBy: MutableList<ChannelUserRead> = mutableListOf()
+    ) : MessageListItem()
+
+    data class ThreadSeparatorItem @JvmOverloads constructor(
+        val date: Date = Date(),
+        override val isMine: Boolean = false,
+        override val messageReadBy: MutableList<ChannelUserRead> = mutableListOf()
+    ) : MessageListItem()
+
+    sealed class Position {
+        object Top : Position()
+        object Middle : Position()
+        object Bottom : Position()
+    }
+}

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItem.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItem.kt
@@ -8,8 +8,6 @@ import java.util.zip.CRC32
 import java.util.zip.Checksum
 
 sealed class MessageListItem {
-    abstract val isMine: Boolean
-    abstract val messageReadBy: MutableList<ChannelUserRead>
 
     fun getStableId(): Long {
         val checksum: Checksum = CRC32()
@@ -25,27 +23,21 @@ sealed class MessageListItem {
 
     data class DateSeparatorItem @JvmOverloads constructor(
         val date: Date,
-        override val isMine: Boolean = false,
-        override val messageReadBy: MutableList<ChannelUserRead> = mutableListOf()
     ) : MessageListItem()
 
     data class MessageItem @JvmOverloads constructor(
         val message: Message,
         val positions: List<Position> = listOf(),
-        override val isMine: Boolean = false,
-        override val messageReadBy: MutableList<ChannelUserRead> = mutableListOf()
+        val isMine: Boolean = false,
+        val messageReadBy: List<ChannelUserRead> = listOf()
     ) : MessageListItem()
 
     data class TypingItem @JvmOverloads constructor(
         val users: List<User>,
-        override val isMine: Boolean = false,
-        override val messageReadBy: MutableList<ChannelUserRead> = mutableListOf()
     ) : MessageListItem()
 
     data class ThreadSeparatorItem @JvmOverloads constructor(
         val date: Date = Date(),
-        override val isMine: Boolean = false,
-        override val messageReadBy: MutableList<ChannelUserRead> = mutableListOf()
     ) : MessageListItem()
 
     sealed class Position {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveData.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveData.kt
@@ -37,7 +37,7 @@ import io.getstream.chat.android.livedata.extensions.getCreatedAtOrThrow
  *
  * Here's an example:
  *
- * MessageListItemLiveData(currentUser, messagesLd, readsLd, typingLd, false) {
+ * MessageListItemLiveData(currentUser, messagesLd, readsLd, typingLd, false) { previous, message ->
  *   return if (previous==null) {
  *       true
  *   } else {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveData.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveData.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MediatorLiveData
 import io.getstream.chat.android.client.models.ChannelUserRead
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
+import java.util.Date
 
 /**
  * It's common for messaging UIs to interleave and group messages
@@ -25,29 +26,153 @@ import io.getstream.chat.android.client.models.User
  *  val day = Date(message.createdAt?.time ?: 0)
  *  SimpleDateFormat("MM / dd").format(day)
  * }
+ *
+ * It improves upon the previous Java code in the sample app in a few ways
+ * - Kotlin
+ * - Typing indicators can be turned on/off
+ * - Date separators can be turned off and are configurable
+ * - Leverages MediatorLiveData to improve handling of null values
+ * - Efficient algorithm for updating read state
+ * - Makes the MessageListItem immutable to prevent future bugs
+ *
+ * TODO:
+ * - How do we handle threads. I don't like the current setup
+ *
  */
-class MessageListItemLiveData(messages: LiveData<List<Message>>, reads: LiveData<List<ChannelUserRead>>, typing: LiveData<List<User>>? = null, dateSeparator: ((m: Message) -> String?)? = null) {
-    val mediator = MediatorLiveData<List<MessageListItem>>()
+data class MessageListItemLiveData(val currentUser: User, val messagesLiveData: LiveData<List<Message>>, val readsLiveData: LiveData<List<ChannelUserRead>>, val typingLiveData: LiveData<List<User>>? = null, val dateSeparator: ((m: Message) -> String?)? = null) : MediatorLiveData<List<MessageListItem>>() {
+
+    private var messageItemsBase = listOf<MessageListItem>()
+    private var messageItemsWithReads = listOf<MessageListItem>()
+
+    private var lastMessageID = ""
+
     init {
-        mediator.addSource(messages) { value ->
-            messagesChanged(messages)
+        addSource(messagesLiveData) { value ->
+            messagesChanged(value)
         }
-        mediator.addSource(reads) { value ->
+        addSource(readsLiveData) { value ->
             readsChanged(value)
         }
-        if (typing != null) {
-            mediator.addSource(typing) { value ->
+        if (typingLiveData != null) {
+            addSource(typingLiveData) { value ->
                 typingChanged(value)
             }
         }
     }
 
-    private fun messagesChanged(messages: LiveData<List<Message>>) {
+    private fun groupMessages(): List<MessageListItem> {
+        val messages = messagesLiveData.value
+
+        if (messages == null || messages.isEmpty()) return emptyList()
+
+        var hasNewMessages = false
+        val newlastMessageID: String = messages.get(messages.size - 1).id
+        if (newlastMessageID != lastMessageID) {
+            hasNewMessages = true
+        }
+        lastMessageID = newlastMessageID
+
+        val entities = mutableListOf<MessageListItem>()
+        val now = Date()
+        var previousMessage: Message? = null
+        val size: Int = messages.size
+        val topIndex = Math.max(0, size - 1)
+
+        for (i in 0 until size) {
+            val message: Message = messages.get(i)
+            var nextMessage: Message? = null
+            if (i + 1 <= topIndex) {
+                nextMessage = messages[i + 1]
+            }
+
+            // determine the position (top, middle, bottom)
+            val user = message.user
+            val positions = mutableListOf<MessageListItem.Position>()
+            if (previousMessage == null || previousMessage.user != user) {
+                positions.add(MessageListItem.Position.Top)
+            }
+            if (nextMessage == null || nextMessage.user != user) {
+                positions.add(MessageListItem.Position.Bottom)
+            }
+            if (previousMessage != null && nextMessage != null) {
+                if (previousMessage.user == user && nextMessage.user == user) {
+                    positions.add(MessageListItem.Position.Middle)
+                }
+            }
+            // date separators
+            if (dateSeparator != null) {
+                previousMessage?.let {
+                    val previousKey = dateSeparator?.let { it(previousMessage!!) }
+                    val currentKey = dateSeparator?.let { it(message) }
+                    if (previousKey != currentKey) {
+                        entities.add(MessageListItem.DateSeparatorItem(message.createdAt ?: now))
+                    }
+                }
+                if (previousMessage == null) {
+                    entities.add(MessageListItem.DateSeparatorItem(message.createdAt ?: now))
+                }
+            }
+
+            val messageListItem: MessageListItem = MessageListItem.MessageItem(message, positions)
+            entities.add(messageListItem)
+            previousMessage = message
+        }
+        return entities.toList()
     }
 
-    private fun readsChanged(value: List<ChannelUserRead>) {
+    private fun addReads(messages: List<MessageListItem>, reads: List<ChannelUserRead>?): List<MessageListItem> {
+        if (reads == null || reads.isEmpty()) return messages
+
+        val sortedReads = reads.sortedByDescending { it.lastRead }.toMutableList()
+        val messagesCopy = messages.toMutableList()
+
+        // start at the end
+        for (messageItem in messages.reversed()) {
+            var index = messages.size - 1
+            if (messageItem is MessageListItem.MessageItem) {
+                val messageItem = messageItem as MessageListItem.MessageItem
+                messageItem.message.createdAt?.let {
+                    while (sortedReads.isNotEmpty()) {
+                        // use the list of sorted reads
+                        val last = sortedReads.last()
+                        if (it.before(last.lastRead)) {
+                            // we got a match
+                            sortedReads.removeLast()
+                            val messageItemCopy = messagesCopy[index] as MessageListItem.MessageItem
+                            val readBy = listOf(last) + messageItemCopy.messageReadBy
+                            val updatedMessageItem = messageItem.copy(messageReadBy = readBy)
+                            // update the message in the message copy
+                            messagesCopy[index] = updatedMessageItem
+                        } else {
+                            // search further in the past for matches
+                            break
+                        }
+                    }
+                }
+            }
+            index--
+        }
+
+        return messagesCopy
     }
 
-    private fun typingChanged(value: List<User>) {
+    private fun messagesChanged(messages: List<Message>) {
+        messageItemsBase = groupMessages()
+        messageItemsWithReads = addReads(messageItemsBase, readsLiveData.value)
+        value = messageItemsWithReads
+    }
+
+    private fun readsChanged(reads: List<ChannelUserRead>) {
+        messageItemsWithReads = addReads(messageItemsBase, readsLiveData.value)
+        value = messageItemsWithReads
+    }
+
+    private fun typingChanged(users: List<User>) {
+        var output = messageItemsWithReads
+        val typingUsers = users.filter { it.id != currentUser.id }
+        if (typingUsers.isNotEmpty()) {
+            output = output + MessageListItem.TypingItem(typingUsers)
+        }
+        value = output
     }
 }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveData.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveData.kt
@@ -1,0 +1,53 @@
+package io.getstream.chat.android.livedata.utils
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import io.getstream.chat.android.client.models.ChannelUserRead
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
+
+/**
+ * It's common for messaging UIs to interleave and group messages
+ *
+ * - subsequent messages from the same user are typically grouped
+ * - read state is typically shown
+ * - date separators are common
+ * - typing indicators are typically shown at the bottom
+ *
+ * The class merges the livedata objects for messages, read state and typing
+ *
+ * - If typing indicators should be used
+ * - How/if to use date separators
+ *
+ * Example date separator
+ *
+ * {
+ *  val day = Date(message.createdAt?.time ?: 0)
+ *  SimpleDateFormat("MM / dd").format(day)
+ * }
+ */
+class MessageListItemLiveData(messages: LiveData<List<Message>>, reads: LiveData<List<ChannelUserRead>>, typing: LiveData<List<User>>? = null, dateSeparator: ((m: Message) -> String?)? = null) {
+    val mediator = MediatorLiveData<List<MessageListItem>>()
+    init {
+        mediator.addSource(messages) { value ->
+            messagesChanged(messages)
+        }
+        mediator.addSource(reads) { value ->
+            readsChanged(value)
+        }
+        if (typing != null) {
+            mediator.addSource(typing) { value ->
+                typingChanged(value)
+            }
+        }
+    }
+
+    private fun messagesChanged(messages: LiveData<List<Message>>) {
+    }
+
+    private fun readsChanged(value: List<ChannelUserRead>) {
+    }
+
+    private fun typingChanged(value: List<User>) {
+    }
+}

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveData.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveData.kt
@@ -123,7 +123,7 @@ class MessageListItemLiveData(val currentUser: User, val messagesLiveData: LiveD
     private fun addReads(messages: List<MessageListItem>, reads: List<ChannelUserRead>?): List<MessageListItem> {
         if (reads == null || reads.isEmpty()) return messages
 
-        val sortedReads = reads.sortedByDescending { it.lastRead }.toMutableList()
+        val sortedReads = reads.sortedBy { it.lastRead }.toMutableList()
         val messagesCopy = messages.toMutableList()
 
         // start at the end
@@ -134,7 +134,7 @@ class MessageListItemLiveData(val currentUser: User, val messagesLiveData: LiveD
                     while (sortedReads.isNotEmpty()) {
                         // use the list of sorted reads
                         val last = sortedReads.last()
-                        if (it.before(last.lastRead)) {
+                        if (it.before(last.lastRead) || it == last.lastRead) {
                             // we got a match
                             sortedReads.removeLast()
                             val reversedIndex = messages.size - i - 1

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemWrapper.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemWrapper.kt
@@ -1,9 +1,12 @@
 package io.getstream.chat.android.livedata.utils
 
+/**
+ * MessageListItemWrapper wraps a list of MessageListItem with a few extra fields.
+ */
 data class MessageListItemWrapper(
+    var items: List<MessageListItem> = listOf(),
     var loadingMore: Boolean = false,
     val hasNewMessages: Boolean = false,
-    var items: List<MessageListItem> = listOf(),
     val isTyping: Boolean = false,
     val isThread: Boolean = false
 )

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemWrapper.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/MessageListItemWrapper.kt
@@ -1,0 +1,9 @@
+package io.getstream.chat.android.livedata.utils
+
+data class MessageListItemWrapper(
+    var loadingMore: Boolean = false,
+    val hasNewMessages: Boolean = false,
+    var items: List<MessageListItem> = listOf(),
+    val isTyping: Boolean = false,
+    val isThread: Boolean = false
+)

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataBenchmark.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataBenchmark.kt
@@ -1,0 +1,58 @@
+package io.getstream.chat.android.livedata.utils
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.getstream.chat.android.client.models.ChannelUserRead
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.livedata.randomMessage
+import io.getstream.chat.android.livedata.randomUser
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.text.SimpleDateFormat
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+class MessageListItemLiveDataBenchmark {
+
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private val currentUser = randomUser()
+
+    private fun simpleDateGroups(message: Message): String? {
+        val day = Date(message.createdAt?.time ?: 0)
+        return SimpleDateFormat("MM / dd").format(day)
+    }
+
+    private fun manyMessages(): MessageListItemLiveData {
+        val messages = mutableListOf<Message>()
+        val users = listOf(randomUser(), randomUser(), randomUser())
+
+        for (i in (0..2)) {
+            val user = users[i]
+            for (y in 0..2) {
+                val message = randomMessage(user = user, createdAt = calendar(2020, 11, i + 1, i + y))
+                messages.add(message)
+            }
+        }
+        val messagesLd: LiveData<List<Message>> = MutableLiveData(messages)
+        // user 0 read till the end, user 1 read the first message, user 3 read is missing
+        val read1 = ChannelUserRead(users[0], messages.last().createdAt)
+        val read2 = ChannelUserRead(users[1], messages.first().createdAt)
+        val reads: LiveData<List<ChannelUserRead>> = MutableLiveData(listOf(read1, read2))
+        val typing: LiveData<List<User>> = MutableLiveData(listOf())
+
+        return MessageListItemLiveData(currentUser, messagesLd, reads, typing, false, ::simpleDateGroups)
+    }
+
+    @Test
+    fun twentyMillis() = benchmarkRule.measureRepeated {
+
+        Thread.sleep(20)
+    }
+}

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataBenchmark.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataBenchmark.kt
@@ -1,26 +1,26 @@
 package io.getstream.chat.android.livedata.utils
 
-import androidx.benchmark.junit4.BenchmarkRule
-import androidx.benchmark.junit4.measureRepeated
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth
 import io.getstream.chat.android.client.models.ChannelUserRead
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.randomMessage
 import io.getstream.chat.android.livedata.randomUser
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.text.SimpleDateFormat
 import java.util.Date
+import kotlin.system.measureTimeMillis
 
 @RunWith(AndroidJUnit4::class)
 class MessageListItemLiveDataBenchmark {
 
-    @get:Rule
-    val benchmarkRule = BenchmarkRule()
+    // TODO: BenchmarkRule is broken unfortunately
+    // @get:Rule
+    // val benchmarkRule = BenchmarkRule()
 
     private val currentUser = randomUser()
 
@@ -31,19 +31,18 @@ class MessageListItemLiveDataBenchmark {
 
     private fun manyMessages(): MessageListItemLiveData {
         val messages = mutableListOf<Message>()
-        val users = listOf(randomUser(), randomUser(), randomUser())
 
-        for (i in (0..2)) {
-            val user = users[i]
-            for (y in 0..2) {
-                val message = randomMessage(user = user, createdAt = calendar(2020, 11, i + 1, i + y))
+        for (i in (0..5)) {
+            val user = randomUser()
+            for (y in 0..50) {
+                val message = randomMessage(user = user, createdAt = calendar(2020, 11, i % 28 + 1, 1, i, y))
                 messages.add(message)
             }
         }
         val messagesLd: LiveData<List<Message>> = MutableLiveData(messages)
         // user 0 read till the end, user 1 read the first message, user 3 read is missing
-        val read1 = ChannelUserRead(users[0], messages.last().createdAt)
-        val read2 = ChannelUserRead(users[1], messages.first().createdAt)
+        val read1 = ChannelUserRead(messages.first().user, messages.last().createdAt)
+        val read2 = ChannelUserRead(messages[10].user, messages.first().createdAt)
         val reads: LiveData<List<ChannelUserRead>> = MutableLiveData(listOf(read1, read2))
         val typing: LiveData<List<User>> = MutableLiveData(listOf())
 
@@ -51,8 +50,52 @@ class MessageListItemLiveDataBenchmark {
     }
 
     @Test
-    fun twentyMillis() = benchmarkRule.measureRepeated {
+    fun `the most frequent change to the message list is typing changes`() {
+        val messageLd = manyMessages()
+        val items = messageLd.getOrAwaitValue().items
 
-        Thread.sleep(20)
+        val duration = measureTimeMillis {
+            for (x in 0..50) {
+                messageLd.typingChanged(listOf(User(id = x.toString())))
+                messageLd.typingChanged(emptyList())
+            }
+        }
+        println("changing typing information 100 times on a message list with ${items.size} items took $duration milliseconds")
+        Truth.assertThat(duration).isLessThan(20)
+    }
+
+    @Test
+    fun `the second most frequent change is read state changes`() {
+        val messageLd = manyMessages()
+        val items = messageLd.getOrAwaitValue().items
+
+        val users = items.filterIsInstance<MessageListItem.MessageItem>().map { it.message.user }.distinct()
+        val messages = items.filterIsInstance<MessageListItem.MessageItem>().map { it.message.createdAt }.takeLast(5)
+        val reads = users.map { ChannelUserRead(it, messages.random()) }
+
+        val duration = measureTimeMillis {
+            for (x in 0..100) {
+                messageLd.readsChanged(reads)
+            }
+        }
+        println("changing read information 100 times on a message list with ${items.size} items took $duration milliseconds")
+        Truth.assertThat(duration).isLessThan(40)
+    }
+
+    @Test
+    fun `new messages dont happen as often`() {
+        val messageLd = manyMessages()
+        val items = messageLd.getOrAwaitValue().items
+
+        val messages = items.filterIsInstance<MessageListItem.MessageItem>().map { it.message }
+
+        val duration = measureTimeMillis {
+            for (x in 0..100) {
+                val newMessages = messages + randomMessage()
+                messageLd.messagesChanged(newMessages)
+            }
+        }
+        println("changing messages 100 times on a message list with ${items.size} items took $duration milliseconds")
+        Truth.assertThat(duration).isLessThan(200)
     }
 }

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataBenchmark.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataBenchmark.kt
@@ -23,11 +23,13 @@ class MessageListItemLiveDataBenchmark {
 
     private val currentUser = randomUser()
 
+    private val threeHours = 1000 * 60 * 60 * 3
+
     private fun simpleDateGroups(previous: Message?, message: Message): Boolean {
         return if (previous == null) {
             true
         } else {
-            (message.getCreatedAtOrThrow().time - previous.getCreatedAtOrThrow().time) > (60 * 60 * 3)
+            (message.getCreatedAtOrThrow().time - previous.getCreatedAtOrThrow().time) > threeHours
         }
     }
 

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataBenchmark.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataBenchmark.kt
@@ -7,12 +7,11 @@ import com.google.common.truth.Truth
 import io.getstream.chat.android.client.models.ChannelUserRead
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.livedata.extensions.getCreatedAtOrThrow
 import io.getstream.chat.android.livedata.randomMessage
 import io.getstream.chat.android.livedata.randomUser
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.text.SimpleDateFormat
-import java.util.Date
 import kotlin.system.measureTimeMillis
 
 @RunWith(AndroidJUnit4::class)
@@ -24,9 +23,12 @@ class MessageListItemLiveDataBenchmark {
 
     private val currentUser = randomUser()
 
-    private fun simpleDateGroups(message: Message): String? {
-        val day = Date(message.createdAt?.time ?: 0)
-        return SimpleDateFormat("MM / dd").format(day)
+    private fun simpleDateGroups(previous: Message?, message: Message): Boolean {
+        return if (previous == null) {
+            true
+        } else {
+            (message.getCreatedAtOrThrow().time - previous.getCreatedAtOrThrow().time) > (60 * 60 * 3)
+        }
     }
 
     private fun manyMessages(): MessageListItemLiveData {

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataTest.kt
@@ -1,0 +1,3 @@
+package io.getstream.chat.android.livedata.utils
+
+class MessageListItemLiveDataTest

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataTest.kt
@@ -15,13 +15,6 @@ import org.junit.runner.RunWith
 import java.text.SimpleDateFormat
 import java.util.Date
 
-/**
- * TODO:
- * - validate how the initial data flow works with .observe
- * - complete testing
- * - see if we need the wrapper
- */
-
 @RunWith(AndroidJUnit4::class)
 class MessageListItemLiveDataTest {
 
@@ -33,7 +26,10 @@ class MessageListItemLiveDataTest {
         val reads: LiveData<List<ChannelUserRead>> = MutableLiveData(listOf())
         val typing: LiveData<List<User>> = MutableLiveData(listOf())
 
-        return MessageListItemLiveData(user, messages, reads, typing)
+        return MessageListItemLiveData(user, messages, reads, typing) {
+            val day = Date(it.createdAt?.time ?: 0)
+            SimpleDateFormat("MM / dd").format(day)
+        }
     }
 
     fun oneMessage(): MessageListItemLiveData {
@@ -44,7 +40,10 @@ class MessageListItemLiveDataTest {
         val reads: LiveData<List<ChannelUserRead>> = MutableLiveData(listOf())
         val typing: LiveData<List<User>> = MutableLiveData(listOf())
 
-        return MessageListItemLiveData(user, messages, reads, typing)
+        return MessageListItemLiveData(user, messages, reads, typing) {
+            val day = Date(it.createdAt?.time ?: 0)
+            SimpleDateFormat("MM / dd").format(day)
+        }
     }
 
     fun manyMessages(): MessageListItemLiveData {
@@ -131,8 +130,8 @@ class MessageListItemLiveDataTest {
     fun `First message should contain the read state`() {
         val messageListItemLd = manyMessages()
         val items = messageListItemLd.getOrAwaitValue()
-        val lastMessage = items.first() as MessageListItem.MessageItem
-        Truth.assertThat(lastMessage.messageReadBy).isNotEmpty()
+        val firstMessage = items[1] as MessageListItem.MessageItem
+        Truth.assertThat(firstMessage.messageReadBy).isNotEmpty()
     }
 
     // test message grouping

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/utils/MessageListItemLiveDataTest.kt
@@ -1,3 +1,168 @@
 package io.getstream.chat.android.livedata.utils
 
-class MessageListItemLiveDataTest
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth
+import io.getstream.chat.android.client.models.ChannelUserRead
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.livedata.randomMessage
+import io.getstream.chat.android.livedata.randomUser
+import io.getstream.chat.android.livedata.utils.MessageListItem.TypingItem
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.text.SimpleDateFormat
+import java.util.Date
+
+/**
+ * TODO:
+ * - validate how the initial data flow works with .observe
+ * - complete testing
+ * - see if we need the wrapper
+ */
+
+@RunWith(AndroidJUnit4::class)
+class MessageListItemLiveDataTest {
+
+    fun emptyMessages(): MessageListItemLiveData {
+        val message = randomMessage()
+        val user = randomUser()
+        val messages: LiveData<List<Message>> = MutableLiveData(listOf())
+        val read = ChannelUserRead(user, Date())
+        val reads: LiveData<List<ChannelUserRead>> = MutableLiveData(listOf())
+        val typing: LiveData<List<User>> = MutableLiveData(listOf())
+
+        return MessageListItemLiveData(user, messages, reads, typing)
+    }
+
+    fun oneMessage(): MessageListItemLiveData {
+        val message = randomMessage()
+        val user = randomUser()
+        val messages: LiveData<List<Message>> = MutableLiveData(listOf(message))
+        val read = ChannelUserRead(user, Date())
+        val reads: LiveData<List<ChannelUserRead>> = MutableLiveData(listOf())
+        val typing: LiveData<List<User>> = MutableLiveData(listOf())
+
+        return MessageListItemLiveData(user, messages, reads, typing)
+    }
+
+    fun manyMessages(): MessageListItemLiveData {
+        val messages = mutableListOf<Message>()
+        val currentUser = randomUser()
+        val users = listOf(randomUser(), randomUser(), randomUser())
+
+        for ((i, x) in (0..2).withIndex()) {
+            val user = users[i]
+            for (y in 0..2) {
+                val message = randomMessage(user = user, createdAt = calendar(2020, 11, i + 1))
+                messages.add(message)
+            }
+        }
+        val messagesLd: LiveData<List<Message>> = MutableLiveData(messages)
+        // user 0 read till the end, user 1 read the first message, user 3 read is missing
+        val read1 = ChannelUserRead(users[0], messages.last().createdAt)
+        val read2 = ChannelUserRead(users[1], messages.first().createdAt)
+        val reads: LiveData<List<ChannelUserRead>> = MutableLiveData(listOf(read1, read2))
+        val typing: LiveData<List<User>> = MutableLiveData(listOf())
+
+        return MessageListItemLiveData(currentUser, messagesLd, reads, typing) {
+            val day = Date(it.createdAt?.time ?: 0)
+            SimpleDateFormat("MM / dd").format(day)
+        }
+    }
+
+    // livedata testing
+    @Test
+    fun `Observe should trigger a recompute`() {
+        val many = oneMessage()
+        val items = many.getOrAwaitValue()
+        Truth.assertThat(items.size).isEqualTo(2)
+        val empty = emptyMessages()
+        val items2 = empty.getOrAwaitValue()
+        Truth.assertThat(items2.size).isEqualTo(0)
+    }
+
+    // test typing indicator logic:
+    @Test
+    fun `Should return an empty list`() {
+        val messageListItemLd = emptyMessages()
+        val items = messageListItemLd.typingChanged(emptyList())
+        Truth.assertThat(items).isEmpty()
+    }
+
+    @Test
+    fun `Should exclude the current user`() {
+        val messageListItemLd = emptyMessages()
+        val typing = listOf(messageListItemLd.currentUser)
+        val items = messageListItemLd.typingChanged(typing)
+        Truth.assertThat(items).isEmpty()
+    }
+
+    @Test
+    fun `Should return only the typing indicator`() {
+        val messageListItemLd = emptyMessages()
+        val items = messageListItemLd.typingChanged(listOf(randomUser()))
+        Truth.assertThat(items.size).isEqualTo(1)
+        Truth.assertThat(items.last()).isInstanceOf(TypingItem::class.java)
+    }
+
+    @Test
+    fun `Should return messages with a typing indicator`() {
+        val messageListItemLd = oneMessage()
+        messageListItemLd.messagesChanged(messageListItemLd.messagesLiveData.value!!)
+        val items = messageListItemLd.typingChanged(listOf(randomUser()))
+        Truth.assertThat(items.size).isEqualTo(3)
+        Truth.assertThat(items.first()).isInstanceOf(MessageListItem.DateSeparatorItem::class.java)
+        Truth.assertThat(items[1]).isInstanceOf(MessageListItem.MessageItem::class.java)
+        Truth.assertThat(items.last()).isInstanceOf(TypingItem::class.java)
+    }
+
+    // test how we merge read state
+    @Test
+    fun `Last message should contain the read state`() {
+        val messageListItemLd = manyMessages()
+        val items = messageListItemLd.getOrAwaitValue()
+        val lastMessage = items.last() as MessageListItem.MessageItem
+        Truth.assertThat(lastMessage.messageReadBy).isNotEmpty()
+    }
+
+    @Test
+    fun `First message should contain the read state`() {
+        val messageListItemLd = manyMessages()
+        val items = messageListItemLd.getOrAwaitValue()
+        val lastMessage = items.first() as MessageListItem.MessageItem
+        Truth.assertThat(lastMessage.messageReadBy).isNotEmpty()
+    }
+
+    // test message grouping
+    @Test
+    fun `There should be 3 messages with a position Top`() {
+        val messageListItemLd = manyMessages()
+        val topMessages = mutableListOf<MessageListItem.Position>()
+        val items = messageListItemLd.getOrAwaitValue()
+        for (item in items) {
+            if (item is MessageListItem.MessageItem) {
+                val messageItem = item as MessageListItem.MessageItem
+                topMessages.addAll(messageItem.positions)
+            }
+        }
+        // there are 3 users, so we should have 3 top sections
+        val correctPositions = listOf(MessageListItem.Position.Top, MessageListItem.Position.Middle, MessageListItem.Position.Bottom)
+        Truth.assertThat(topMessages).isEqualTo(correctPositions + correctPositions + correctPositions)
+    }
+
+    // test data separators
+    @Test
+    fun `There should be 3 date separators`() {
+        val messageListItemLd = manyMessages()
+        val separators = mutableListOf<MessageListItem.DateSeparatorItem>()
+        val items = messageListItemLd.getOrAwaitValue()
+        for (item in items) {
+            if (item is MessageListItem.DateSeparatorItem) {
+                separators.add(item)
+            }
+        }
+        Truth.assertThat(separators.size).isEqualTo(3)
+    }
+}


### PR DESCRIPTION
/**
 * It's common for messaging UIs to interleave and group messages
 *
 * - subsequent messages from the same user are typically grouped
 * - read state is typically shown (either as part of the message or separately)
 * - date separators are common
 * - typing indicators are typically shown at the bottom
 *
 * The MessageListItemLiveData class merges the livedata objects for messages, read state and typing
 *
 * It improves upon the previous Java code in the sample app in a few ways
 * - Kotlin
 * - Typing indicators can be turned on/off
 * - Date separators can be turned off and are configurable
 * - Read state matches to the right message
 * - Leverages MediatorLiveData to improve handling of null values
 * - Efficient algorithm for updating read state
 * - Efficient code for updating typing state
 * - Makes the MessageListItem immutable to prevent future bugs
 * - Improved test coverage
*/

Stats, note that typing and read events are more common than messages:

```
changing messages 100 times on a message list with 312 items took 31 milliseconds
changing typing information 100 times on a message list with 312 items took 2 milliseconds
changing read information 100 times on a message list with 312 items took 4 milliseconds
```