### PR TITLE
first notes on sort problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # To be released:
 - Improve sync data validation in ChatDomain.Builder
 - Removed many internal implementation classes and methods from the SDK's public API
-
 - Significant performance improvements to offline storage
 - Default message limit for the queryChannels use case changed from 10 to 1. This is a more sensible default for the channel list view of most chat apps
+- Fix QuerySort 
+- Update client to 1.16.8: See changes: https://github.com/GetStream/stream-chat-android-client/releases/tag/1.16.8
 
 # Oct 14th, 2020 - 0.8.5
 

--- a/livedata/build.gradle
+++ b/livedata/build.gradle
@@ -74,7 +74,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    api "com.github.getstream:stream-chat-android-client:1.16.7"
+    api "com.github.getstream:stream-chat-android-client:1.16.8"
 
     def room_version = "2.2.5"
     def work_version = "2.4.0"

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -51,6 +51,7 @@ internal class QueryChannelsControllerImpl(
 
     private val _channels = MutableLiveData<Map<String, Channel>>()
     // Ensure we don't lose the sort in the channel
+    // TODO: The live list of channels doesn't actually maintain the specified query sort
     override var channels: LiveData<List<Channel>> = Transformations.map(_channels) { cMap -> queryEntity.channelCids.mapNotNull { cMap[it] } }
 
     private val logger = ChatLogger.get("ChatDomain QueryChannelsController")

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
@@ -113,12 +113,23 @@ internal val QuerySort.comparator: Comparator<in ChannelEntityPair>
     get() =
         CompositeComparator(data.mapNotNull { it.comparator as? Comparator<ChannelEntityPair> })
 
+val snakeRegex = "_[a-zA-Z]".toRegex()
+/**
+ * turns created_at into createdAt
+ */
+fun String.snakeToLowerCamelCase(): String {
+    return snakeRegex.replace(this) {
+        it.value.replace("_", "")
+            .toUpperCase()
+    }
+}
+
 internal val Map<String, Any>.comparator: Comparator<in ChannelEntityPair>?
     get() =
         (this["field"] as? String)?.let { fieldName ->
             (this["direction"] as? Int)?.let { sortDirection ->
                 Channel::class.declaredMemberProperties
-                    .find { it.name == fieldName }
+                    .find { it.name == fieldName.snakeToLowerCamelCase() }
                     ?.comparator(sortDirection)
             }
         }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
@@ -113,11 +113,11 @@ internal val QuerySort.comparator: Comparator<in ChannelEntityPair>
     get() =
         CompositeComparator(data.mapNotNull { it.comparator as? Comparator<ChannelEntityPair> })
 
-val snakeRegex = "_[a-zA-Z]".toRegex()
+private val snakeRegex = "_[a-zA-Z]".toRegex()
 /**
  * turns created_at into createdAt
  */
-fun String.snakeToLowerCamelCase(): String {
+internal fun String.snakeToLowerCamelCase(): String {
     return snakeRegex.replace(this) {
         it.value.replace("_", "")
             .toUpperCase()

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/PaginationTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/PaginationTest.kt
@@ -1,11 +1,11 @@
 package io.getstream.chat.android.livedata
 
-import com.google.common.truth.Truth
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.livedata.entity.ChannelEntityPair
 import io.getstream.chat.android.livedata.extensions.applyPagination
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
 import io.getstream.chat.android.livedata.utils.calendar
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -20,8 +20,7 @@ internal class PaginationTest {
         expectedList: List<ChannelEntityPair>
     ) {
         // show an easy to use diff between the two results
-        val result = inputList.applyPagination(pagination).map { it.channel.cid }
-        Truth.assertThat(result).isEqualTo(expectedList.map { it.channel.cid })
+        inputList.applyPagination(pagination) `should be equal to` expectedList
     }
 
     companion object {
@@ -168,8 +167,8 @@ internal class PaginationTest {
             },
             // last_updated is a computed field based on max(createdAt, lastMessageAt)
             listOf(
-                randomChannelEntityPair(channel = randomChannel(cid = "c", lastMessageAt = calendar(2020, 10, 2))),
-                randomChannelEntityPair(channel = randomChannel(cid = "a", createdAt = calendar(2020, 10, 4))),
+                randomChannelEntityPair(channel = randomChannel(cid = "c", createdAt = null, lastMessageAt = calendar(2020, 10, 2))),
+                randomChannelEntityPair(channel = randomChannel(cid = "a", createdAt = calendar(2020, 10, 4), lastMessageAt = null)),
                 randomChannelEntityPair(channel = randomChannel(cid = "b", createdAt = calendar(2020, 10, 1), lastMessageAt = calendar(2020, 10, 3)))
             ).let {
                 Arguments.of(

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/PaginationTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/PaginationTest.kt
@@ -197,6 +197,22 @@ internal class PaginationTest {
                     },
                     listOf(it[1], it[2], it[0])
                 )
+            },
+            // last_message_at should map to channel.lastMessageAt
+            listOf(
+                randomChannelEntityPair(channel = randomChannel(cid = "c", lastMessageAt = calendar(2020, 10, 2))),
+                randomChannelEntityPair(channel = randomChannel(cid = "a", lastMessageAt = calendar(2020, 10, 4))),
+                randomChannelEntityPair(channel = randomChannel(cid = "b", lastMessageAt = calendar(2020, 10, 3)))
+            ).let {
+                Arguments.of(
+                    it,
+                    AnyChannelPaginationRequest().apply {
+                        sort = QuerySort().apply {
+                            desc("last_message_at")
+                        }
+                    },
+                    listOf(it[1], it[2], it[0])
+                )
             }
         )
     }


### PR DESCRIPTION
Depend on https://github.com/GetStream/stream-chat-android-client/pull/110

Fix #21 

the sort changes between online and offline query. this is caused by the offline sort not working. 

see this video for clarification: https://www.loom.com/share/d956c3cb4353480ba9c321a9d026de0d

I investigated it a little bit, few issues:

1. - the backend uses field names like created_at which on the channel object are called createdAt, these don't match
2. - the default ordering is last_updated which is actually a composite field based on max(createdAt, lastMessageAt)
3. - you can receive new channels via an event. the current sort implementation is not applied after receiving an event. it's only used for the offline version of the channels.

I added a failing test for the first 2 issues.

1. - i added a fix for this. number 3 is also easy to solve by changing that Transform where I added a comment.

supporting last_updated is a bit harder, any ideas?

- maybe an extension function on the Channel object?


