### PR TITLE
Remove usages of java.security.InvalidParameterException

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/repository/MessageRepository.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/repository/MessageRepository.kt
@@ -10,7 +10,6 @@ import io.getstream.chat.android.livedata.dao.MessageDao
 import io.getstream.chat.android.livedata.entity.MessageEntity
 import io.getstream.chat.android.livedata.extensions.isPermanent
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
-import java.security.InvalidParameterException
 import java.util.Date
 
 class MessageRepository(var messageDao: MessageDao, var cacheSize: Int = 100, var currentUser: User, var client: ChatClient) {
@@ -66,9 +65,7 @@ class MessageRepository(var messageDao: MessageDao, var cacheSize: Int = 100, va
     suspend fun insert(messageEntities: List<MessageEntity>, cache: Boolean = false) {
         if (messageEntities.isEmpty()) return
         for (messageEntity in messageEntities) {
-            if (messageEntity.cid == "") {
-                throw InvalidParameterException("message.cid cant be empty")
-            }
+            require(messageEntity.cid.isNotEmpty()) { "message.cid can not be empty" }
         }
         for (m in messageEntities) {
             if (messageCache.get(m.id) != null || cache) {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/repository/ReactionRepository.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/repository/ReactionRepository.kt
@@ -7,7 +7,6 @@ import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.dao.ReactionDao
 import io.getstream.chat.android.livedata.entity.ReactionEntity
 import io.getstream.chat.android.livedata.extensions.isPermanent
-import java.security.InvalidParameterException
 
 /**
  * We don't do any caching on reactions since usage is infrequent
@@ -29,15 +28,9 @@ class ReactionRepository(var reactionDao: ReactionDao, var currentUser: User, va
 
     suspend fun insert(reactionEntities: List<ReactionEntity>) {
         for (reactionEntity in reactionEntities) {
-            if (reactionEntity.messageId.isEmpty()) {
-                throw InvalidParameterException("message id can't be empty when creating a reaction")
-            }
-            if (reactionEntity.type.isEmpty()) {
-                throw InvalidParameterException("type can't be empty when creating a reaction")
-            }
-            if (reactionEntity.userId.isEmpty()) {
-                throw InvalidParameterException("user id can't be empty when creating a reaction")
-            }
+            require(reactionEntity.messageId.isNotEmpty()) { "message id can't be empty when creating a reaction" }
+            require(reactionEntity.type.isNotEmpty()) { "type can't be empty when creating a reaction" }
+            require(reactionEntity.userId.isNotEmpty()) { "user id can't be empty when creating a reaction" }
         }
 
         reactionDao.insert(reactionEntities)

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/ThreadLoadMoreImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/usecase/ThreadLoadMoreImpl.kt
@@ -5,7 +5,6 @@ import io.getstream.chat.android.livedata.ChatDomainImpl
 import io.getstream.chat.android.livedata.utils.Call2
 import io.getstream.chat.android.livedata.utils.CallImpl2
 import io.getstream.chat.android.livedata.utils.validateCid
-import java.security.InvalidParameterException
 
 interface ThreadLoadMore {
     /**
@@ -23,9 +22,7 @@ interface ThreadLoadMore {
 class ThreadLoadMoreImpl(var domainImpl: ChatDomainImpl) : ThreadLoadMore {
     override operator fun invoke(cid: String, parentId: String, messageLimit: Int): Call2<List<Message>> {
         validateCid(cid)
-        if (parentId.isEmpty()) {
-            throw InvalidParameterException("parentId cant be empty")
-        }
+        require(parentId.isNotEmpty()) { "parentId can't be empty" }
 
         val channelController = domainImpl.channel(cid)
         val threadController = channelController.getThread(parentId)

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/Validation.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/Validation.kt
@@ -1,15 +1,9 @@
 package io.getstream.chat.android.livedata.utils
 
-import java.security.InvalidParameterException
-
 /**
  * Validates a cid. Verifies it's not empty and in the format messaging:123
  */
 fun validateCid(cid: String) {
-    if (cid.isEmpty()) {
-        throw InvalidParameterException("cid cant be empty")
-    }
-    if (!cid.contains(":")) {
-        throw InvalidParameterException("cid needs to be in the format channelType:channelId. For example messaging:123")
-    }
+    require(cid.isNotEmpty()) { "cid can not be empty" }
+    require(":" in cid) { "cid needs to be in the format channelType:channelId. For example, messaging:123" }
 }

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/GetThreadImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/GetThreadImplTest.kt
@@ -20,7 +20,6 @@ import org.amshove.kluent.invoking
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.security.InvalidParameterException
 
 @RunWith(AndroidJUnit4::class)
 class GetThreadImplTest {
@@ -42,14 +41,14 @@ class GetThreadImplTest {
     fun `Should throw an exception if the channel cid is empty`() {
         invoking {
             getThreadImpl("", randomString())
-        } `should throw` InvalidParameterException::class `with message` "cid cant be empty"
+        } `should throw` IllegalArgumentException::class `with message` "cid can not be empty"
     }
 
     @Test
     fun `Should throw an exception if the channel cid doesn't contain a colon`() {
         invoking {
             getThreadImpl(randomString().replace(":", ""), randomString())
-        } `should throw` InvalidParameterException::class`with message` "cid needs to be in the format channelType:channelId. For example messaging:123"
+        } `should throw` IllegalArgumentException::class`with message` "cid needs to be in the format channelType:channelId. For example, messaging:123"
     }
     @Test
     fun `Should return a ThreadController`() {

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/SendMessageWithAttachmentsImplTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/SendMessageWithAttachmentsImplTest.kt
@@ -39,7 +39,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import java.io.File
-import java.security.InvalidParameterException
 
 @RunWith(AndroidJUnit4::class)
 @Ignore
@@ -60,14 +59,14 @@ class SendMessageWithAttachmentsImplTest {
     fun `Should throw an exception if the channel cid is empty`() {
         invoking {
             sendMessageWithAttachemen("", randomMessage(), randomFiles())
-        } `should throw` InvalidParameterException::class `with message` "cid cant be empty"
+        } `should throw` IllegalArgumentException::class `with message` "cid can not be empty"
     }
 
     @Test
     fun `Should throw an exception if the channel cid doesn't contain a colon`() {
         invoking {
             sendMessageWithAttachemen(randomString().replace(":", ""), randomMessage(), randomFiles())
-        } `should throw` InvalidParameterException::class`with message` "cid needs to be in the format channelType:channelId. For example messaging:123"
+        } `should throw` IllegalArgumentException::class `with message` "cid needs to be in the format channelType:channelId. For example, messaging:123"
     }
 
     @Test

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/SendMessageWithFilesTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/usecase/SendMessageWithFilesTest.kt
@@ -26,7 +26,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import java.io.File
-import java.security.InvalidParameterException
 
 @RunWith(AndroidJUnit4::class)
 internal class SendMessageWithFilesTest : BaseConnectedMockedTest() {
@@ -219,7 +218,7 @@ internal class SendMessageWithFilesTest : BaseConnectedMockedTest() {
 
         invoking {
             sendMessageWithFile(message)
-        } `should throw` InvalidParameterException::class `with message` "cid cant be empty"
+        } `should throw` IllegalArgumentException::class `with message` "cid can not be empty"
     }
 
     @Test
@@ -230,7 +229,7 @@ internal class SendMessageWithFilesTest : BaseConnectedMockedTest() {
 
         invoking {
             sendMessageWithFile(message)
-        } `should throw` InvalidParameterException::class`with message` "cid needs to be in the format channelType:channelId. For example messaging:123"
+        } `should throw` IllegalArgumentException::class `with message` "cid needs to be in the format channelType:channelId. For example, messaging:123"
     }
 }
 


### PR DESCRIPTION
### Description

[`InvalidParameterException`](https://docs.oracle.com/javase/8/docs/api/java/security/InvalidParameterException.html) is a class meant to be used by Java security APIs. The application level exception with the correct semantics is [`IllegalArgumentException`](https://docs.oracle.com/javase/8/docs/api/java/lang/IllegalArgumentException.html) (which is easily thrown by [`require`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/require.html)).

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] New code is covered by unit tests
- [x] Reviewers added
