### PR TITLE
CAS-275 Handle error when message is sent during cool down interval

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChannelData.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChannelData.kt
@@ -28,6 +28,8 @@ public data class ChannelData(var type: String, var channelId: String) {
     var deletedAt: Date? = null
     /** all the custom data provided for this channel */
     var extraData: MutableMap<String, Any> = mutableMapOf()
+    /** minimum interval between user messages (in seconds) in slow down mode **/
+    var cooldown: Int = 0
 
     /** create a ChannelData object from a Channel object */
     public constructor(c: Channel) : this(c.type, c.id) {
@@ -36,6 +38,7 @@ public data class ChannelData(var type: String, var channelId: String) {
         updatedAt = c.updatedAt
         deletedAt = c.deletedAt
         extraData = c.extraData
+        cooldown = c.cooldown
 
         createdBy = c.createdBy
     }
@@ -53,6 +56,7 @@ public data class ChannelData(var type: String, var channelId: String) {
         c.extraData = extraData
         c.lastMessageAt = messages.lastOrNull()?.let { it.createdAt ?: it.createdLocallyAt }
         c.createdBy = createdBy
+        c.cooldown = cooldown
 
         c.messages = messages
         c.members = members

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChannelData.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChannelData.kt
@@ -11,7 +11,11 @@ import java.util.Date
  * A class that only stores the channel data and not all the other channel state
  * Using this prevents code bugs and issues caused by confusing the channel data vs the full channel object
  */
-public data class ChannelData(var type: String, var channelId: String) {
+public data class ChannelData(
+    var type: String,
+    var channelId: String,
+    val cooldown: Int = 0
+) {
     var cid: String = "%s:%s".format(type, channelId)
 
     /** created by user */
@@ -28,24 +32,21 @@ public data class ChannelData(var type: String, var channelId: String) {
     var deletedAt: Date? = null
     /** all the custom data provided for this channel */
     var extraData: MutableMap<String, Any> = mutableMapOf()
-    /** minimum interval between user messages (in seconds) in slow down mode **/
-    var cooldown: Int = 0
 
     /** create a ChannelData object from a Channel object */
-    public constructor(c: Channel) : this(c.type, c.id) {
+    public constructor(c: Channel) : this(c.type, c.id, c.cooldown) {
         frozen = c.frozen
         createdAt = c.createdAt
         updatedAt = c.updatedAt
         deletedAt = c.deletedAt
         extraData = c.extraData
-        cooldown = c.cooldown
 
         createdBy = c.createdBy
     }
 
     /** convert a channelEntity into a channel object */
     internal fun toChannel(messages: List<Message>, members: List<Member>, reads: List<ChannelUserRead>, watchers: List<User>, watcherCount: Int): Channel {
-        val c = Channel()
+        val c = Channel(cooldown = cooldown)
         c.type = type
         c.id = channelId
         c.cid = cid
@@ -56,7 +57,6 @@ public data class ChannelData(var type: String, var channelId: String) {
         c.extraData = extraData
         c.lastMessageAt = messages.lastOrNull()?.let { it.createdAt ?: it.createdLocallyAt }
         c.createdBy = createdBy
-        c.cooldown = cooldown
 
         c.messages = messages
         c.members = members

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
@@ -39,7 +39,7 @@ import io.getstream.chat.android.livedata.entity.UserEntity
         ChannelConfigEntity::class,
         SyncStateEntity::class
     ],
-    version = 22,
+    version = 23,
     exportSchema = false
 )
 

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -268,7 +268,7 @@ internal class ChatDomainImpl private constructor(
 
         while (true) {
             result = runnable().execute()
-            if (result.isSuccess) {
+            if (result.isSuccess || result.error().isPermanent()) {
                 break
             } else {
                 // retry logic

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
@@ -62,6 +62,8 @@ internal data class ChannelEntity(var type: String, var channelId: String) {
     var deletedAt: Date? = null
     /** all the custom data provided for this channel */
     var extraData = mutableMapOf<String, Any>()
+    /** minimum interval between user messages (in seconds) in slow down mode **/
+    var cooldown: Int = 0
 
     /** if the channel has been synced to the servers */
     var syncStatus: SyncStatus = SyncStatus.COMPLETED
@@ -74,6 +76,7 @@ internal data class ChannelEntity(var type: String, var channelId: String) {
         deletedAt = c.deletedAt
         extraData = c.extraData
         syncStatus = c.syncStatus
+        cooldown = c.cooldown
 
         members = mutableMapOf()
         for (m in c.members) {
@@ -103,6 +106,7 @@ internal data class ChannelEntity(var type: String, var channelId: String) {
         c.extraData = extraData
         c.lastMessageAt = lastMessageAt
         c.syncStatus = syncStatus
+        c.cooldown = cooldown
 
         c.members = members.values.mapNotNull { it.toMember(userMap) }
 

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/DefaultRetryPolicy.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/DefaultRetryPolicy.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.livedata.utils
 
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.livedata.extensions.isPermanent
 
 internal class DefaultRetryPolicy : RetryPolicy {
     override fun shouldRetry(
@@ -9,7 +10,7 @@ internal class DefaultRetryPolicy : RetryPolicy {
         attempt: Int,
         error: ChatError
     ): Boolean {
-        return attempt < 3
+        return attempt < 3 && !error.isPermanent()
     }
 
     /**

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/utils/DefaultRetryPolicy.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/utils/DefaultRetryPolicy.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.android.livedata.utils
 
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.errors.ChatError
-import io.getstream.chat.android.livedata.extensions.isPermanent
 
 internal class DefaultRetryPolicy : RetryPolicy {
     override fun shouldRetry(
@@ -10,7 +9,7 @@ internal class DefaultRetryPolicy : RetryPolicy {
         attempt: Int,
         error: ChatError
     ): Boolean {
-        return attempt < 3 && !error.isPermanent()
+        return attempt < 3
     }
 
     /**

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/ChatErrorTest.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/ChatErrorTest.kt
@@ -38,4 +38,10 @@ internal class ChatErrorTest : BaseConnectedIntegrationTest() {
         val error = ChatNetworkError.create(0, "", 500, null)
         Truth.assertThat(error.isPermanent()).isFalse()
     }
+
+    @Test
+    fun `cool down period error should be permanent`() {
+        val error = ChatNetworkError.create(60, "", 403, null)
+        Truth.assertThat(error.isPermanent()).isTrue()
+    }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-275

### Description
Changes retry logic in a way that requests that return permanent errors from the server are not retried. As a result, user is instantly notified about message delivery errors when he/she tries to send them during cool down period. Ideally, on the UI side, there should be a timeout in `MessageInputView` preventing user from submitting a message during cool down period.

- Ensured that `cooldown` property is propagated to the UI
- Disabled retries for permanent errors including cool down interval errors (status code - 403, stream code - 60)

To be merged after this  [PR to the LLC](https://github.com/GetStream/stream-chat-android-client/pull/111) is merged and released.

### Checklist

- [X] have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [X] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
