### PR TITLE
Fix/event handler

### DIFF
--- a/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -672,7 +672,7 @@ internal class ChatDomainImpl private constructor(
         channelIds: List<String>,
         pagination: AnyChannelPaginationRequest
     ): List<Channel> {
-        return repos.selectChannels(channelIds, pagination, defaultConfig).applyPagination(pagination)
+        return repos.selectChannels(channelIds, defaultConfig, pagination).applyPagination(pagination)
     }
 
     override fun clean() {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
@@ -3,8 +3,7 @@ package io.getstream.chat.android.livedata
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.livedata.entity.ChannelEntity
-import io.getstream.chat.android.livedata.entity.MessageEntity
+import io.getstream.chat.android.livedata.extensions.updateLastMessage
 import io.getstream.chat.android.livedata.extensions.users
 
 /**
@@ -26,91 +25,85 @@ import io.getstream.chat.android.livedata.extensions.users
  * fourth, execute the batch using
  * batch.execute()
  */
-internal class EventBatchUpdate private constructor (private val domainImpl: ChatDomainImpl, private val channelMap: Map<String, ChannelEntity>, private val messageMap: Map<String, MessageEntity>) {
-    val users: MutableMap<String, User> = mutableMapOf()
-    val channels: MutableMap<String, ChannelEntity> = mutableMapOf()
-    val messages: MutableMap<String, MessageEntity> = mutableMapOf()
+internal class EventBatchUpdate private constructor(
+    private val domainImpl: ChatDomainImpl,
+    channelMap: Map<String, Channel>,
+    messageMap: Map<String, Message>
+) {
+    private var users: Map<String, User> = emptyMap()
+    private var channels: Map<String, Channel> = channelMap
+    private var messages: Map<String, Message> = messageMap
 
     internal class Builder {
-        private val channelsToFetch = mutableSetOf<String>()
-        private val messagesToFetch = mutableSetOf<String>()
+        private var channelsToFetch = setOf<String>()
+        private var messagesToFetch = setOf<String>()
+        private var users = setOf<User>()
 
         fun addToFetchChannels(cIds: List<String>) {
-            channelsToFetch += cIds
+            channelsToFetch = channelsToFetch + cIds
         }
 
         fun addToFetchChannels(cId: String) {
-            channelsToFetch += listOf(cId)
+            channelsToFetch = channelsToFetch + listOf(cId)
         }
 
         fun addToFetchMessages(ids: List<String>) {
-            messagesToFetch += ids
+            messagesToFetch = messagesToFetch + ids
         }
 
         fun addToFetchMessages(id: String) {
-            messagesToFetch += id
+            messagesToFetch = messagesToFetch + id
         }
 
-        fun build(domainImpl: ChatDomainImpl): EventBatchUpdate {
-            // TODO fix it
-            val messageMap: Map<String, MessageEntity> = emptyMap() // domainImpl.repos.messages.select(messagesToFetch.toList()).associateBy { it.id }
-            val channelMap: Map<String, ChannelEntity> = emptyMap() // domainImpl.repos.channels.select(channelsToFetch.toList()).associateBy { it.cid }
+        fun addUsers(usersToAdd: List<User>) {
+            users = users + usersToAdd
+        }
+
+        suspend fun build(domainImpl: ChatDomainImpl): EventBatchUpdate {
+            val messageMap: Map<String, Message> = domainImpl.repos.selectMessages(messagesToFetch.toList()).associateBy(Message::id)
+            val channelMap: Map<String, Channel> = domainImpl.repos.selectChannels(channelsToFetch.toList(), domainImpl.defaultConfig).associateBy(Channel::cid)
             return EventBatchUpdate(domainImpl, channelMap, messageMap)
         }
     }
 
     fun addMessageData(cid: String, message: Message) {
-        // TODO rewrite it
-        /*addMessage(MessageEntity(message), message.users())
+        addMessage(message)
 
-        getCurrentChannel(cid)?.let {
-            it.updateLastMessage(MessageEntity(message))
-            addChannelEntity(it, emptyList())
-        }*/
+        getCurrentChannel(cid)?.also { channel -> channel.updateLastMessage(message) }
     }
 
     fun addChannel(channel: Channel) {
         // ensure we store all users for this channel
         addUsers(channel.users())
         // TODO: this overwrites members which in the case when you have > 100 members isn't the right behaviour
-        channels[channel.cid] = ChannelEntity(channel)
+        channels = channels + (channel.cid to channel)
     }
 
-    fun addChannelEntity(channelEntity: ChannelEntity, channelUsers: List<User>) {
+    fun getCurrentChannel(cId: String): Channel? = channels[cId]
+    fun getCurrentMessage(messageId: String): Message? = messages[messageId]
+
+    fun addMessage(message: Message) {
         // ensure we store all users for this channel
-        addUsers(channelUsers)
-        channels[channelEntity.cid] = channelEntity
-    }
-
-    fun getCurrentChannel(cId: String): ChannelEntity? {
-        return channels[cId] ?: channelMap[cId]
-    }
-
-    fun getCurrentMessage(messageId: String): MessageEntity? {
-        return messages[messageId] ?: messageMap[messageId]
-    }
-
-    fun addMessage(messageEntity: MessageEntity, messageUsers: List<User>) {
-        // ensure we store all users for this channel
-        addUsers(messageUsers)
-        messages[messageEntity.id] = messageEntity
+        addUsers(message.users())
+        messages = messages + (message.id to message)
     }
 
     fun addUsers(newUsers: List<User>) {
-        users.putAll(newUsers.associateBy(User::id))
+        users = users + newUsers.associateBy(User::id)
     }
 
     fun addUser(newUser: User) {
-        addUsers(listOf(newUser))
+        users = users + (newUser.id to newUser)
     }
 
     suspend fun execute() {
         // actually insert the data
-        users.remove(domainImpl.currentUser.id)?.let { domainImpl.updateCurrentUser(it) }
+        val currentUser = domainImpl.currentUser
+        domainImpl.updateCurrentUser(currentUser)
+        users = users - currentUser.id
         domainImpl.repos.users.insert(users.values.toList())
-        domainImpl.repos.channels.insert(channels.values.toList())
+        domainImpl.repos.channels.insertChannels(channels.values)
         // we only cache messages for which we're receiving events
-        // TODO fixit
-        // domainImpl.repos.messages.insert(messages.values.toList(), true)
+        domainImpl.repos.messages.insert(messages.values.toList(), true)
     }
 }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
@@ -11,17 +11,17 @@ import io.getstream.chat.android.livedata.extensions.users
  * EventBatchUpdate helps you efficiently implement a 4 step batch update process
  * It updates multiple messages, users and channels at once.
  *
- * val batch = EventBatchUpdate(domainImpl)
+ * val batchBuilder = EventBatchUpdate.Builder()
  *
  * as a first step specify which channels and messages to fetch
- * batch.addToFetchChannels()
- * batch.addToFetchMessages()
+ * batchBuilder.addToFetchChannels()
+ * batchBuilder.addToFetchMessages()
  *
  * as a second step, load the required data for batch updating using
- * batch.fetch()
+ * val batch = batchBuilder.build(domainImpl)
  *
  * third, add the required updates via
- * addUser, addChannel and addMessage methods
+ * batch.addUser, addChannel and addMessage methods
  *
  * fourth, execute the batch using
  * batch.execute()

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
@@ -49,7 +49,6 @@ internal class EventBatchUpdate(private val domainImpl: ChatDomainImpl) {
     }
 
     fun addChannel(channel: Channel) {
-        require(fetchCompleted) { "be sure to run batch.fetch before calling this method" }
         // ensure we store all users for this channel
         addUsers(channel.users())
         // TODO: this overwrites members which in the case when you have > 100 members isn't the right behaviour
@@ -57,7 +56,6 @@ internal class EventBatchUpdate(private val domainImpl: ChatDomainImpl) {
     }
 
     fun addChannelEntity(channelEntity: ChannelEntity, channelUsers: List<User>) {
-        require(fetchCompleted) { "be sure to run batch.fetch before calling this method" }
         // ensure we store all users for this channel
         addUsers(channelUsers)
         channels[channelEntity.cid] = channelEntity
@@ -74,19 +72,16 @@ internal class EventBatchUpdate(private val domainImpl: ChatDomainImpl) {
     }
 
     fun addMessage(messageEntity: MessageEntity, messageUsers: List<User>) {
-        require(fetchCompleted) { "be sure to run batch.fetch before calling this method" }
         // ensure we store all users for this channel
         addUsers(messageUsers)
         messages[messageEntity.id] = messageEntity
     }
 
     fun addUsers(newUsers: List<User>) {
-        require(fetchCompleted) { "be sure to run batch.fetch before calling this method" }
         users.putAll(newUsers.associateBy(User::id))
     }
 
     fun addUser(newUser: User) {
-        require(fetchCompleted) { "be sure to run batch.fetch before calling this method" }
         addUsers(listOf(newUser))
     }
 
@@ -113,6 +108,7 @@ internal class EventBatchUpdate(private val domainImpl: ChatDomainImpl) {
     }
 
     suspend fun execute() {
+        require(fetchCompleted) { "be sure to run batch.fetch before calling this method" }
         // actually insert the data
         users.remove(domainImpl.currentUser.id)?.let { domainImpl.updateCurrentUser(it) }
         domainImpl.repos.users.insert(users.values.toList())

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
@@ -53,8 +53,8 @@ internal class EventBatchUpdate private constructor (private val domainImpl: Cha
 
         fun build(domainImpl: ChatDomainImpl): EventBatchUpdate {
             // TODO fix it
-            val messageMap: Map<String, MessageEntity> = emptyMap()//domainImpl.repos.messages.select(messagesToFetch.toList()).associateBy { it.id }
-            val channelMap: Map<String, ChannelEntity> = emptyMap()//domainImpl.repos.channels.select(channelsToFetch.toList()).associateBy { it.cid }
+            val messageMap: Map<String, MessageEntity> = emptyMap() // domainImpl.repos.messages.select(messagesToFetch.toList()).associateBy { it.id }
+            val channelMap: Map<String, ChannelEntity> = emptyMap() // domainImpl.repos.channels.select(channelsToFetch.toList()).associateBy { it.cid }
             return EventBatchUpdate(domainImpl, channelMap, messageMap)
         }
     }
@@ -111,6 +111,6 @@ internal class EventBatchUpdate private constructor (private val domainImpl: Cha
         domainImpl.repos.channels.insert(channels.values.toList())
         // we only cache messages for which we're receiving events
         // TODO fixit
-        //domainImpl.repos.messages.insert(messages.values.toList(), true)
+        // domainImpl.repos.messages.insert(messages.values.toList(), true)
     }
 }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
@@ -52,19 +52,21 @@ internal class EventBatchUpdate private constructor (private val domainImpl: Cha
         }
 
         fun build(domainImpl: ChatDomainImpl): EventBatchUpdate {
-            val messageMap = domainImpl.repos.messages.select(messagesToFetch.toList()).associateBy { it.id }
-            val channelMap = domainImpl.repos.channels.select(channelsToFetch.toList()).associateBy { it.cid }
+            // TODO fix it
+            val messageMap: Map<String, MessageEntity> = emptyMap()//domainImpl.repos.messages.select(messagesToFetch.toList()).associateBy { it.id }
+            val channelMap: Map<String, ChannelEntity> = emptyMap()//domainImpl.repos.channels.select(channelsToFetch.toList()).associateBy { it.cid }
             return EventBatchUpdate(domainImpl, channelMap, messageMap)
         }
     }
 
     fun addMessageData(cid: String, message: Message) {
-        addMessage(MessageEntity(message), message.users())
+        // TODO rewrite it
+        /*addMessage(MessageEntity(message), message.users())
 
         getCurrentChannel(cid)?.let {
             it.updateLastMessage(MessageEntity(message))
             addChannelEntity(it, emptyList())
-        }
+        }*/
     }
 
     fun addChannel(channel: Channel) {
@@ -108,6 +110,7 @@ internal class EventBatchUpdate private constructor (private val domainImpl: Cha
         domainImpl.repos.users.insert(users.values.toList())
         domainImpl.repos.channels.insert(channels.values.toList())
         // we only cache messages for which we're receiving events
-        domainImpl.repos.messages.insert(messages.values.toList(), true)
+        // TODO fixit
+        //domainImpl.repos.messages.insert(messages.values.toList(), true)
     }
 }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
@@ -1,0 +1,113 @@
+package io.getstream.chat.android.livedata
+
+import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.livedata.entity.ChannelEntity
+import io.getstream.chat.android.livedata.entity.MessageEntity
+import io.getstream.chat.android.livedata.extensions.users
+
+/**
+ * EventBatchUpdate helps you efficiently implement a 4 step batch update process
+ * It updates multiple messages, users and channels at once.
+ *
+ * val batch = EventBatchUpdate(domainImpl)
+ *
+ * as a first step specify which channels and messages to fetch
+ * batch.addToFetchChannels()
+ * batch.addToFetchMessages()
+ *
+ * as a second step, load the required data for batch updating using
+ * batch.fetch()
+ *
+ * third, add the required updates via
+ * addUser, addChannel and addMessage methods
+ *
+ * fourth, execute the batch using
+ * batch.execute()
+ */
+internal class EventBatchUpdate(private val domainImpl: ChatDomainImpl) {
+    val users: MutableMap<String, User> = mutableMapOf()
+    val channels: MutableMap<String, ChannelEntity> = mutableMapOf()
+
+    val messages: MutableMap<String, MessageEntity> = mutableMapOf()
+    private val channelsToFetch = mutableSetOf<String>()
+    private val messagesToFetch = mutableSetOf<String>()
+
+    private lateinit var channelMap: Map<String, ChannelEntity>
+    private lateinit var messageMap: Map<String, MessageEntity>
+
+    fun addMessageData(cid: String, message: Message) {
+        users.putAll(message.users().associateBy(User::id))
+        messages[message.id] = MessageEntity(message)
+        channelMap[cid]?.let {
+            it.updateLastMessage(MessageEntity(message))
+            channels[it.cid] = it
+        }
+    }
+
+    fun addChannel(channel: Channel) {
+        // ensure we store all users for this channel
+        addUsers(channel.users())
+        // TODO: this overwrites members which in the case when you have > 100 members isn't the right behaviour
+        channels[channel.cid] = ChannelEntity(channel)
+    }
+
+    fun addChannelEntity(channelEntity: ChannelEntity, channelUsers: List<User>) {
+        // ensure we store all users for this channel
+        addUsers(channelUsers)
+        channels[channelEntity.cid] = channelEntity
+    }
+
+    fun getCurrentChannel(cId: String): ChannelEntity? {
+        return channels[cId] ?: channelMap[cId]
+    }
+
+    fun getCurrentMessage(messageId: String): MessageEntity? {
+        return messages[messageId] ?: messageMap[messageId]
+    }
+
+    fun addMessage(messageEntity: MessageEntity, messageUsers: List<User>) {
+        // ensure we store all users for this channel
+        addUsers(messageUsers)
+        messages[messageEntity.id] = messageEntity
+    }
+
+    fun addUsers(newUsers: List<User>) {
+        users.putAll(newUsers.associateBy(User::id))
+    }
+
+    fun addUser(newUser: User) {
+        addUsers(listOf(newUser))
+    }
+
+    fun addToFetchChannels(cIds: List<String>) {
+        channelsToFetch += cIds
+    }
+
+    fun addToFetchChannels(cId: String) {
+        channelsToFetch += listOf(cId)
+    }
+
+    fun addToFetchMessages(ids: List<String>) {
+        messagesToFetch += ids
+    }
+
+    fun addToFetchMessages(id: String) {
+        messagesToFetch += id
+    }
+
+    suspend fun fetch() {
+        messageMap = domainImpl.repos.messages.select(messagesToFetch.toList()).associateBy { it.id }
+        channelMap = domainImpl.repos.channels.select(channelsToFetch.toList()).associateBy { it.cid }
+    }
+
+    suspend fun execute() {
+        // actually insert the data
+        users.remove(domainImpl.currentUser.id)?.let { domainImpl.updateCurrentUser(it) }
+        domainImpl.repos.users.insert(users.values.toList())
+        domainImpl.repos.channels.insert(channels.values.toList())
+        // we only cache messages for which we're receiving events
+        domainImpl.repos.messages.insert(messages.values.toList(), true)
+    }
+}

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
@@ -36,6 +36,7 @@ internal class EventBatchUpdate(private val domainImpl: ChatDomainImpl) {
 
     private lateinit var channelMap: Map<String, ChannelEntity>
     private lateinit var messageMap: Map<String, MessageEntity>
+    // TODO: use a builder approach to have a better concept of steps for this object
     private var fetchCompleted: Boolean = false
 
     fun addMessageData(cid: String, message: Message) {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -56,13 +56,8 @@ import io.getstream.chat.android.client.events.UserUnmutedEvent
 import io.getstream.chat.android.client.events.UserUpdatedEvent
 import io.getstream.chat.android.client.events.UsersMutedEvent
 import io.getstream.chat.android.client.events.UsersUnmutedEvent
-import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.ChannelUserRead
-import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.livedata.entity.ChannelEntity
-import io.getstream.chat.android.livedata.entity.MessageEntity
-import io.getstream.chat.android.livedata.extensions.users
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -88,21 +83,18 @@ internal class EventHandlerImpl(
     internal suspend fun updateOfflineStorageFromEvents(events: List<ChatEvent>) {
         events.sortedBy(ChatEvent::createdAt)
 
-        val users: MutableMap<String, User> = mutableMapOf()
-        val channels: MutableMap<String, ChannelEntity> = mutableMapOf()
+        val batch = EventBatchUpdate(domainImpl)
 
-        val messages: MutableMap<String, MessageEntity> = mutableMapOf()
-        val channelsToFetch = mutableSetOf<String>()
-        val messagesToFetch = mutableSetOf<String>()
-
-        events.filterIsInstance<CidEvent>().onEach { channelsToFetch += it.cid }
+        val eventChannels = events.filterIsInstance<CidEvent>().map { it.cid }
+        batch.addToFetchChannels(eventChannels)
         // For some reason backend is not sending us the user instance into some events that they should
         // and we are not able to identify which event type is. Gson, because it is using reflection,
         // inject a null instance into property `user` that doesn't allow null values.
         // This is a workaround, while we identify which event type is, that omit null values without
         // break our public API
         @Suppress("USELESS_CAST")
-        users += events.filterIsInstance<UserEvent>().mapNotNull { it.user as User? }.associateBy(User::id)
+        val eventUsers = events.filterIsInstance<UserEvent>().mapNotNull { it.user as User? }
+        batch.addUsers(eventUsers)
 
         // step 1. see which data we need to retrieve from offline storage
         for (event in events) {
@@ -148,62 +140,25 @@ internal class EventHandlerImpl(
                 is UserStartWatchingEvent,
                 is UserStopWatchingEvent,
                 is ChannelUserUnbannedEvent -> Unit
-                is ReactionNewEvent -> messagesToFetch += event.reaction.messageId
-                is ReactionDeletedEvent -> messagesToFetch += event.reaction.messageId
-                is ChannelMuteEvent -> channelsToFetch += event.channelMute.channel.cid
+                is ReactionNewEvent -> batch.addToFetchMessages(event.reaction.messageId)
+                is ReactionDeletedEvent -> batch.addToFetchMessages(event.reaction.messageId)
+                is ChannelMuteEvent -> batch.addToFetchChannels(event.channelMute.channel.cid)
                 is ChannelsMuteEvent -> {
-                    event.channelsMute.forEach { channelsToFetch.add(it.channel.cid) }
+                    event.channelsMute.forEach { batch.addToFetchChannels(it.channel.cid) }
                 }
-                is ChannelUnmuteEvent -> channelsToFetch += event.channelMute.channel.cid
+                is ChannelUnmuteEvent -> batch.addToFetchChannels(event.channelMute.channel.cid)
                 is ChannelsUnmuteEvent -> {
-                    event.channelsMute.forEach { channelsToFetch.add(it.channel.cid) }
+                    event.channelsMute.forEach { batch.addToFetchChannels(it.channel.cid) }
                 }
-                is MessageDeletedEvent -> messagesToFetch += event.message.id
-                is MessageUpdatedEvent -> messagesToFetch += event.message.id
-                is NewMessageEvent -> messagesToFetch += event.message.id
-                is NotificationMessageNewEvent -> messagesToFetch += event.message.id
-                is ReactionUpdateEvent -> messagesToFetch += event.message.id
+                is MessageDeletedEvent -> batch.addToFetchMessages(event.message.id)
+                is MessageUpdatedEvent -> batch.addToFetchMessages(event.message.id)
+                is NewMessageEvent -> batch.addToFetchMessages(event.message.id)
+                is NotificationMessageNewEvent -> batch.addToFetchMessages(event.message.id)
+                is ReactionUpdateEvent -> batch.addToFetchMessages(event.message.id)
             }.exhaustive
         }
         // actually fetch the data
-        val channelMap = domainImpl.repos.channels.select(channelsToFetch.toList()).associateBy { it.cid }
-        val messageMap = domainImpl.repos.messages.select(messagesToFetch.toList()).associateBy { it.id }
-
-        fun addMessageData(cid: String, message: Message) {
-            users.putAll(message.users().associateBy(User::id))
-            messages[message.id] = MessageEntity(message)
-            channelMap[cid]?.let {
-                it.updateLastMessage(MessageEntity(message))
-                channels[it.cid] = it
-            }
-        }
-
-        fun addChannel(channel: Channel) {
-            // ensure we store all users for this channel
-            users.putAll(channel.users().associateBy(User::id))
-            // TODO: this overwrites members which in the case when you have > 100 members isn't the right behaviour
-            channels[channel.cid] = ChannelEntity(channel)
-        }
-
-        fun addChannelEntity(channelEntity: ChannelEntity, channelUsers: List<User>) {
-            // ensure we store all users for this channel
-            users.putAll(channelUsers.associateBy(User::id))
-            channels[channelEntity.cid] = channelEntity
-        }
-
-        fun getCurrentChannel(cId: String): ChannelEntity? {
-            return channels[cId] ?: channelMap[cId]
-        }
-
-        fun getCurrentMessage(messageId: String): MessageEntity? {
-            return messages[messageId] ?: messageMap[messageId]
-        }
-
-        fun addMessage(messageEntity: MessageEntity, messageUsers: List<User>) {
-            // ensure we store all users for this channel
-            users.putAll(messageUsers.associateBy(User::id))
-            messages[messageEntity.id] = messageEntity
-        }
+        batch.fetch()
 
         // step 2. second pass through the events, make a list of what we need to update
         loop@ for (event in events) {
@@ -214,45 +169,45 @@ internal class EventHandlerImpl(
                 is NewMessageEvent -> {
                     event.message.cid = event.cid
                     event.totalUnreadCount?.let { domainImpl.setTotalUnreadCount(it) }
-                    addMessageData(event.cid, event.message)
+                    batch.addMessageData(event.cid, event.message)
                 }
                 is MessageDeletedEvent -> {
                     event.message.cid = event.cid
-                    addMessageData(event.cid, event.message)
+                    batch.addMessageData(event.cid, event.message)
                 }
                 is MessageUpdatedEvent -> {
                     event.message.cid = event.cid
-                    addMessageData(event.cid, event.message)
+                    batch.addMessageData(event.cid, event.message)
                 }
                 is NotificationMessageNewEvent -> {
                     event.message.cid = event.cid
                     event.totalUnreadCount?.let { domainImpl.setTotalUnreadCount(it) }
-                    addMessageData(event.cid, event.message)
+                    batch.addMessageData(event.cid, event.message)
                 }
                 is NotificationAddedToChannelEvent -> {
-                    addChannel(event.channel)
+                    batch.addChannel(event.channel)
                 }
                 is NotificationInvitedEvent -> {
-                    users[event.user.id] = event.user
+                    batch.addUser(event.user)
                 }
                 is NotificationInviteAcceptedEvent -> {
-                    users[event.user.id] = event.user
+                    batch.addUser(event.user)
                 }
                 is ChannelHiddenEvent -> {
-                    getCurrentChannel(event.cid)?.let {
+                    batch.getCurrentChannel(event.cid)?.let {
                         val updatedChannel = it.apply {
                             hidden = true
                             hideMessagesBefore = event.createdAt.takeIf { event.clearHistory }
                         }
-                        addChannelEntity(updatedChannel, emptyList())
+                        batch.addChannelEntity(updatedChannel, emptyList())
                     }
                 }
                 is ChannelVisibleEvent -> {
-                    getCurrentChannel(event.cid)?.let {
+                    batch.getCurrentChannel(event.cid)?.let {
                         val updatedChannel = it.apply {
                             hidden = false
                         }
-                        addChannelEntity(updatedChannel, emptyList())
+                        batch.addChannelEntity(updatedChannel, emptyList())
                     }
                 }
                 is NotificationMutesUpdatedEvent -> {
@@ -266,132 +221,132 @@ internal class EventHandlerImpl(
                     // get the message, update the reaction data, update the message
                     // note that we need to use event.reaction and not event.message
                     // event.message only has a subset of reactions
-                    getCurrentMessage(event.reaction.messageId)?.let {
+                    batch.getCurrentMessage(event.reaction.messageId)?.let {
                         val updatedMessage = it.apply {
                             addReaction(event.reaction, domainImpl.currentUser.id == event.user.id)
                         }
-                        addMessage(updatedMessage, emptyList())
+                        batch.addMessage(updatedMessage, emptyList())
                     }
                 }
                 is ReactionDeletedEvent -> {
                     // get the message, update the reaction data, update the message
-                    getCurrentMessage(event.reaction.messageId)?.let {
+                    batch.getCurrentMessage(event.reaction.messageId)?.let {
                         val updatedMessage = it.apply {
                             removeReaction(event.reaction, false)
                             reactionCounts = event.message.reactionCounts
                         }
-                        addMessage(updatedMessage, emptyList())
+                        batch.addMessage(updatedMessage, emptyList())
                     }
                 }
                 is ReactionUpdateEvent -> {
-                    getCurrentMessage(event.reaction.messageId)?.let {
+                    batch.getCurrentMessage(event.reaction.messageId)?.let {
                         val updatedMessage = it.apply {
                             addReaction(event.reaction, domainImpl.currentUser.id == event.user.id)
                         }
-                        addMessage(updatedMessage, emptyList())
+                        batch.addMessage(updatedMessage, emptyList())
                     }
                 }
                 is MemberAddedEvent -> {
-                    getCurrentChannel(event.cid)?.let {
+                    batch.getCurrentChannel(event.cid)?.let {
                         val updatedChannel = it.apply { setMember(event.member.user.id, event.member) }
-                        addChannelEntity(updatedChannel, listOf(event.member.user))
+                        batch.addChannelEntity(updatedChannel, listOf(event.member.user))
                     }
                 }
                 is MemberUpdatedEvent -> {
-                    getCurrentChannel(event.cid)?.let {
+                    batch.getCurrentChannel(event.cid)?.let {
                         val updatedChannel = it.apply { setMember(event.member.user.id, event.member) }
-                        addChannelEntity(updatedChannel, listOf(event.member.user))
+                        batch.addChannelEntity(updatedChannel, listOf(event.member.user))
                     }
                 }
                 is MemberRemovedEvent -> {
-                    getCurrentChannel(event.cid)?.let {
+                    batch.getCurrentChannel(event.cid)?.let {
                         val updatedChannel = it.apply { setMember(event.user.id, null) }
-                        addChannelEntity(updatedChannel, listOf(event.user))
+                        batch.addChannelEntity(updatedChannel, listOf(event.user))
                     }
                 }
                 is NotificationRemovedFromChannelEvent -> {
-                    getCurrentChannel(event.cid)?.let {
+                    batch.getCurrentChannel(event.cid)?.let {
                         val updatedChannel = it.apply { setMember(event.user.id, null) }
-                        addChannelEntity(updatedChannel, listOf(event.user))
+                        batch.addChannelEntity(updatedChannel, listOf(event.user))
                     }
                 }
                 is ChannelUpdatedEvent -> {
-                    addChannel(event.channel)
+                    batch.addChannel(event.channel)
                 }
                 is ChannelUpdatedByUserEvent -> {
-                    addChannel(event.channel)
+                    batch.addChannel(event.channel)
                 }
                 is ChannelDeletedEvent -> {
-                    addChannel(event.channel)
+                    batch.addChannel(event.channel)
                 }
                 is ChannelCreatedEvent -> {
-                    addChannel(event.channel)
+                    batch.addChannel(event.channel)
                 }
                 is ChannelMuteEvent -> {
-                    addChannel(event.channelMute.channel)
+                    batch.addChannel(event.channelMute.channel)
                 }
                 is ChannelsMuteEvent -> {
                     event.channelsMute.forEach {
-                        addChannel(it.channel)
+                        batch.addChannel(it.channel)
                     }
                 }
                 is ChannelUnmuteEvent -> {
-                    addChannel(event.channelMute.channel)
+                    batch.addChannel(event.channelMute.channel)
                 }
                 is ChannelsUnmuteEvent -> {
                     event.channelsMute.forEach {
-                        addChannel(it.channel)
+                        batch.addChannel(it.channel)
                     }
                 }
                 is ChannelTruncatedEvent -> {
-                    addChannel(event.channel)
+                    batch.addChannel(event.channel)
                 }
                 is NotificationChannelDeletedEvent -> {
-                    addChannel(event.channel)
+                    batch.addChannel(event.channel)
                 }
                 is NotificationChannelMutesUpdatedEvent -> {
                     domainImpl.updateCurrentUser(event.me)
                 }
                 is NotificationChannelTruncatedEvent -> {
-                    addChannel(event.channel)
+                    batch.addChannel(event.channel)
                 }
 
                 is MessageReadEvent -> {
                     // get the channel, update reads, write the channel
-                    getCurrentChannel(event.cid)?.let {
+                    batch.getCurrentChannel(event.cid)?.let {
                         val updatedChannel = it.apply {
                             updateReads(ChannelUserRead(user = event.user, lastRead = event.createdAt))
                         }
-                        addChannelEntity(updatedChannel, listOf(event.user))
+                        batch.addChannelEntity(updatedChannel, listOf(event.user))
                     }
                 }
                 is NotificationMarkReadEvent -> {
                     event.totalUnreadCount?.let { domainImpl.setTotalUnreadCount(it) }
 
-                    getCurrentChannel(event.cid)?.let {
+                    batch.getCurrentChannel(event.cid)?.let {
                         val updatedChannel = it.apply {
                             updateReads(ChannelUserRead(user = event.user, lastRead = event.createdAt))
                         }
-                        addChannelEntity(updatedChannel, listOf(event.user))
+                        batch.addChannelEntity(updatedChannel, listOf(event.user))
                     }
                 }
                 is UserMutedEvent -> {
-                    users[event.targetUser.id] = event.targetUser
+                    batch.addUser(event.targetUser)
                 }
                 is UsersMutedEvent -> {
-                    event.targetUsers.forEach { users[it.id] = it }
+                    batch.addUsers(event.targetUsers)
                 }
                 is UserUnmutedEvent -> {
-                    users[event.targetUser.id] = event.targetUser
+                    batch.addUser(event.targetUser)
                 }
                 is UsersUnmutedEvent -> {
-                    event.targetUsers.forEach { users[it.id] = it }
+                    batch.addUsers(event.targetUsers)
                 }
                 is GlobalUserBannedEvent -> {
-                    users[event.user.id] = event.user.apply { banned = true }
+                    batch.addUser(event.user.apply { banned = true })
                 }
                 is GlobalUserUnbannedEvent -> {
-                    users[event.user.id] = event.user.apply { banned = false }
+                    batch.addUser(event.user.apply { banned = false })
                 }
                 is TypingStartEvent,
                 is TypingStopEvent,
@@ -409,12 +364,9 @@ internal class EventHandlerImpl(
                 is UserStopWatchingEvent -> Unit
             }.exhaustive
         }
-        // actually insert the data
-        users.remove(domainImpl.currentUser.id)?.let { domainImpl.updateCurrentUser(it) }
-        domainImpl.repos.users.insert(users.values.toList())
-        domainImpl.repos.channels.insert(channels.values.toList())
-        // we only cache messages for which we're receiving events
-        domainImpl.repos.messages.insert(messages.values.toList(), true)
+
+        // execute the batch
+        batch.execute()
 
         // handle delete and truncate events
         for (event in events) {

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -225,7 +225,7 @@ internal class EventHandlerImpl(
                         val updatedMessage = it.apply {
                             addReaction(event.reaction, domainImpl.currentUser.id == event.user.id)
                         }
-                        batch.addMessage(updatedMessage, emptyList())
+                        batch.addMessage(updatedMessage, listOfNotNull(event.reaction.user))
                     }
                 }
                 is ReactionDeletedEvent -> {
@@ -235,7 +235,7 @@ internal class EventHandlerImpl(
                             removeReaction(event.reaction, false)
                             reactionCounts = event.message.reactionCounts
                         }
-                        batch.addMessage(updatedMessage, emptyList())
+                        batch.addMessage(updatedMessage, listOfNotNull(event.reaction.user))
                     }
                 }
                 is ReactionUpdateEvent -> {
@@ -243,7 +243,7 @@ internal class EventHandlerImpl(
                         val updatedMessage = it.apply {
                             addReaction(event.reaction, domainImpl.currentUser.id == event.user.id)
                         }
-                        batch.addMessage(updatedMessage, emptyList())
+                        batch.addMessage(updatedMessage, listOfNotNull(event.reaction.user))
                     }
                 }
                 is MemberAddedEvent -> {
@@ -303,6 +303,10 @@ internal class EventHandlerImpl(
                 }
                 is NotificationChannelDeletedEvent -> {
                     batch.addChannel(event.channel)
+                    // note that NotificationChannelDeletedEvent doesn't implement UserEvent
+                    event.user?.let {
+                        batch.addUser(it)
+                    }
                 }
                 is NotificationChannelMutesUpdatedEvent -> {
                     domainImpl.updateCurrentUser(event.me)

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -94,7 +94,8 @@ internal class EventHandlerImpl(
         // break our public API
         @Suppress("USELESS_CAST")
         val eventUsers = events.filterIsInstance<UserEvent>().mapNotNull { it.user as User? }
-        batchBuilder.addUsers(eventUsers)
+        // TODO fixit
+        // batchBuilder.addUsers(eventUsers)
 
         // step 1. see which data we need to retrieve from offline storage
         for (event in events) {
@@ -223,7 +224,8 @@ internal class EventHandlerImpl(
                     // event.message only has a subset of reactions
                     batch.getCurrentMessage(event.reaction.messageId)?.let {
                         val updatedMessage = it.apply {
-                            addReaction(event.reaction, domainImpl.currentUser.id == event.user.id)
+                            // TODO fixit
+                            // addReaction(event.reaction, domainImpl.currentUser.id == event.user.id)
                         }
                         batch.addMessage(updatedMessage, listOfNotNull(event.reaction.user))
                     }
@@ -232,14 +234,16 @@ internal class EventHandlerImpl(
                     // get the message, update the reaction data, update the message
                     batch.getCurrentMessage(event.reaction.messageId)?.let {
                         val updatedMessage = it.copy(reactionCounts = event.message.reactionCounts)
-                        it.removeReaction(event.reaction, false)
+                        // TODO fixit
+                        // it.removeReaction(event.reaction, false)
                         batch.addMessage(updatedMessage, listOfNotNull(event.reaction.user))
                     }
                 }
                 is ReactionUpdateEvent -> {
                     batch.getCurrentMessage(event.reaction.messageId)?.let {
                         val updatedMessage = it.apply {
-                            addReaction(event.reaction, domainImpl.currentUser.id == event.user.id)
+                            // TODO fixit
+                            // addReaction(event.reaction, domainImpl.currentUser.id == event.user.id)
                         }
                         batch.addMessage(updatedMessage, listOfNotNull(event.reaction.user))
                     }

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
@@ -6,7 +6,6 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.ChannelUserRead
-import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.repository.MessageRepository
@@ -79,6 +78,7 @@ internal data class ChannelEntity(var type: String, var channelId: String) {
         extraData = c.extraData
         syncStatus = c.syncStatus
         hidden = c.hidden
+        hideMessagesBefore = c.hiddenMessagesBefore
 
         members = mutableMapOf()
         for (m in c.members) {
@@ -110,6 +110,7 @@ internal data class ChannelEntity(var type: String, var channelId: String) {
         c.lastMessageAt = lastMessageAt
         c.syncStatus = syncStatus
         c.hidden = hidden
+        c.hiddenMessagesBefore = hideMessagesBefore
 
         c.members = members.values.mapNotNull { it.toMember(userMap) }
 
@@ -143,14 +144,6 @@ internal data class ChannelEntity(var type: String, var channelId: String) {
     fun updateReads(read: ChannelUserRead) {
         val readEntity = ChannelUserReadEntity(read)
         reads[read.getUserId()] = readEntity
-    }
-
-    fun setMember(userId: String, member: Member?) {
-        if (member == null) {
-            members.remove(userId)
-        } else {
-            members[userId] = MemberEntity(member)
-        }
     }
 
     private fun max(date: Date?, otherDate: Date?): Date? =

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
@@ -38,6 +38,10 @@ internal class ChannelRepository(
         }
     }
 
+    suspend fun insertChannels(channels: Collection<Channel>) {
+        insert(channels.map(::ChannelEntity))
+    }
+
     suspend fun insert(channelEntities: List<ChannelEntity>) {
         if (channelEntities.isEmpty()) return
         channelDao.insertMany(channelEntities)

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/repository/MessageRepository.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/repository/MessageRepository.kt
@@ -31,9 +31,9 @@ internal class MessageRepository(
 
     internal suspend fun selectMessagesEntitiesForChannel(
         cid: String,
-        pagination: AnyChannelPaginationRequest
+        pagination: AnyChannelPaginationRequest?
     ): List<MessageEntity> {
-        if (pagination.hasFilter()) {
+        if (pagination != null && pagination.hasFilter()) {
             // handle the differences between gt, gte, lt and lte
             val message = messageDao.select(pagination.messageFilterValue)
             if (message?.createdAt == null) return listOf()
@@ -55,7 +55,7 @@ internal class MessageRepository(
                 }
             }
         }
-        return messageDao.messagesForChannel(cid, pagination.messageLimit)
+        return messageDao.messagesForChannel(cid, pagination?.messageLimit ?: DEFAULT_MESSAGE_LIMIT)
     }
 
     suspend fun select(messageIds: List<String>, usersMap: Map<String, User>): List<Message> {
@@ -125,6 +125,8 @@ internal class MessageRepository(
     }
 
     companion object {
+        private const val DEFAULT_MESSAGE_LIMIT = 100
+
         internal fun toModel(entity: MessageEntity, userMap: Map<String, User>): Message = with(entity) {
             val message = Message()
             message.id = id

--- a/livedata/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
+++ b/livedata/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
@@ -51,12 +51,12 @@ internal class RepositoryHelper(
 
     internal suspend fun selectChannels(
         channelIds: List<String>,
-        pagination: AnyChannelPaginationRequest,
-        defaultConfig: Config
+        defaultConfig: Config,
+        pagination: AnyChannelPaginationRequest? = null
     ): List<Channel> {
         // fetch the channel entities from room
         val channelEntities = channels.select(channelIds)
-        val messageEntitiesMap = if (pagination.isRequestingMoreThanLastMessage()) {
+        val messageEntitiesMap = if (pagination?.isRequestingMoreThanLastMessage() != false) {
             // with postgres this could be optimized into a single query instead of N, not sure about sqlite on android
             // sqlite has window functions: https://sqlite.org/windowfunctions.html
             // but android runs a very dated version: https://developer.android.com/reference/android/database/sqlite/package-summary

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTests.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/repository/MessageRepositoryTests.kt
@@ -1,9 +1,17 @@
 package io.getstream.chat.android.livedata.repository
 
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import io.getstream.chat.android.livedata.dao.MessageDao
+import io.getstream.chat.android.livedata.randomMessage
+import io.getstream.chat.android.livedata.randomMessageEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.When
+import org.amshove.kluent.calling
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 @ExperimentalCoroutinesApi
 internal class MessageRepositoryTests {
@@ -16,5 +24,23 @@ internal class MessageRepositoryTests {
     fun setup() {
         messageDao = mock()
         sut = MessageRepository(messageDao)
+    }
+
+    @Test
+    fun `Given 2 messages in cache When select message entities Should return message from dao and cache`() = runBlockingTest {
+        val cachedMessage1 = randomMessage(id = "id1")
+        val cachedMessage2 = randomMessage(id = "id2")
+        sut.insert(listOf(cachedMessage1, cachedMessage2), true)
+        val messageEntityFromDb1 = randomMessageEntity(id = "id3")
+        val messageEntityFromDb2 = randomMessageEntity(id = "id4")
+        When calling messageDao.select(listOf("id3", "id4")) doReturn listOf(messageEntityFromDb1, messageEntityFromDb2)
+
+        val result = sut.selectEntities(listOf("id1", "id2", "id3", "id4"))
+
+        result.size shouldBeEqualTo 4
+        result.any { it.id == "id1" } shouldBeEqualTo true
+        result.any { it.id == "id2" } shouldBeEqualTo true
+        result.contains(messageEntityFromDb1) shouldBeEqualTo true
+        result.contains(messageEntityFromDb2) shouldBeEqualTo true
     }
 }

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/repository/RepositoryHelperTests.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/repository/RepositoryHelperTests.kt
@@ -130,7 +130,7 @@ internal class RepositoryHelperTests {
             }
             When calling channels.select(listOf("cid1", "cid2")) doReturn listOf(channelEntity1, channelEntity2)
 
-            val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest, mock())
+            val result = sut.selectChannels(listOf("cid1", "cid2"), mock(), paginationRequest)
 
             result.size shouldBeEqualTo 2
             result.any { it.cid == "cid1" && it.messages.isEmpty() } shouldBeEqualTo true
@@ -160,7 +160,7 @@ internal class RepositoryHelperTests {
             }
             When calling channels.select(listOf("cid1", "cid2")) doReturn listOf(channelEntity1, channelEntity2)
 
-            val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest, mock())
+            val result = sut.selectChannels(listOf("cid1", "cid2"), mock(), paginationRequest)
 
             result.size shouldBeEqualTo 2
             result.any { it.cid == "cid1" && it.messages.size == 1 && it.messages.first().id == "messageId1" } shouldBeEqualTo true

--- a/livedata/src/test/java/io/getstream/chat/android/livedata/repository/RepositoryHelperTests.kt
+++ b/livedata/src/test/java/io/getstream/chat/android/livedata/repository/RepositoryHelperTests.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.livedata.repository
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
+import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.randomCID
 import io.getstream.chat.android.livedata.randomChannelEntity
 import io.getstream.chat.android.livedata.randomChannelUserReadEntity
@@ -115,48 +116,84 @@ internal class RepositoryHelperTests {
     }
 
     @Test
-    fun `Given request less than last message When select channels Should return channels from DB with empty messages`() = runBlockingTest {
-        val paginationRequest = AnyChannelPaginationRequest(0)
-        When calling users.selectUserMap(any()) doReturn mapOf("userId" to randomUser(id = "userId"))
-        val channelEntity1 = randomChannelEntity().apply {
-            cid = "cid1"
-            createdByUserId = "userId"
-        }
-        val channelEntity2 = randomChannelEntity().apply {
-            cid = "cid2"
-            createdByUserId = "userId"
-        }
-        When calling channels.select(listOf("cid1", "cid2")) doReturn listOf(channelEntity1, channelEntity2)
+    fun `Given request less than last message When select channels Should return channels from DB with empty messages`() =
+        runBlockingTest {
+            val paginationRequest = AnyChannelPaginationRequest(0)
+            When calling users.selectUserMap(any()) doReturn mapOf("userId" to randomUser(id = "userId"))
+            val channelEntity1 = randomChannelEntity().apply {
+                cid = "cid1"
+                createdByUserId = "userId"
+            }
+            val channelEntity2 = randomChannelEntity().apply {
+                cid = "cid2"
+                createdByUserId = "userId"
+            }
+            When calling channels.select(listOf("cid1", "cid2")) doReturn listOf(channelEntity1, channelEntity2)
 
-        val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest, mock())
+            val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest, mock())
 
-        result.size shouldBeEqualTo 2
-        result.any { it.cid == "cid1" && it.messages.isEmpty() } shouldBeEqualTo true
-        result.any { it.cid == "cid2" && it.messages.isEmpty() } shouldBeEqualTo true
-    }
+            result.size shouldBeEqualTo 2
+            result.any { it.cid == "cid1" && it.messages.isEmpty() } shouldBeEqualTo true
+            result.any { it.cid == "cid2" && it.messages.isEmpty() } shouldBeEqualTo true
+        }
 
     @Test
-    fun `Given request more than last message When select channels Should return channels from DB with messages`() = runBlockingTest {
-        val paginationRequest = AnyChannelPaginationRequest(100)
-        When calling users.selectUserMap(any()) doReturn mapOf("userId" to randomUser(id = "userId"))
-        val messageEntity1 = randomMessageEntity(id = "messageId1", cid = "cid1", userId = "userId")
-        val messageEntity2 = randomMessageEntity(id = "messageId2", cid = "cid2", userId = "userId")
-        When calling messages.selectMessagesEntitiesForChannel("cid1", paginationRequest) doReturn listOf(messageEntity1)
-        When calling messages.selectMessagesEntitiesForChannel("cid2", paginationRequest) doReturn listOf(messageEntity2)
-        val channelEntity1 = randomChannelEntity().apply {
-            cid = "cid1"
-            createdByUserId = "userId"
-        }
-        val channelEntity2 = randomChannelEntity().apply {
-            cid = "cid2"
-            createdByUserId = "userId"
-        }
-        When calling channels.select(listOf("cid1", "cid2")) doReturn listOf(channelEntity1, channelEntity2)
+    fun `Given request more than last message When select channels Should return channels from DB with messages`() =
+        runBlockingTest {
+            val paginationRequest = AnyChannelPaginationRequest(100)
+            When calling users.selectUserMap(any()) doReturn mapOf("userId" to randomUser(id = "userId"))
+            val messageEntity1 = randomMessageEntity(id = "messageId1", cid = "cid1", userId = "userId")
+            val messageEntity2 = randomMessageEntity(id = "messageId2", cid = "cid2", userId = "userId")
+            When calling messages.selectMessagesEntitiesForChannel("cid1", paginationRequest) doReturn listOf(
+                messageEntity1
+            )
+            When calling messages.selectMessagesEntitiesForChannel("cid2", paginationRequest) doReturn listOf(
+                messageEntity2
+            )
+            val channelEntity1 = randomChannelEntity().apply {
+                cid = "cid1"
+                createdByUserId = "userId"
+            }
+            val channelEntity2 = randomChannelEntity().apply {
+                cid = "cid2"
+                createdByUserId = "userId"
+            }
+            When calling channels.select(listOf("cid1", "cid2")) doReturn listOf(channelEntity1, channelEntity2)
 
-        val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest, mock())
+            val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest, mock())
+
+            result.size shouldBeEqualTo 2
+            result.any { it.cid == "cid1" && it.messages.size == 1 && it.messages.first().id == "messageId1" } shouldBeEqualTo true
+            result.any { it.cid == "cid2" && it.messages.size == 1 && it.messages.first().id == "messageId2" } shouldBeEqualTo true
+        }
+
+    @Test
+    fun `Given Db contains all required data When select messages Should return message list`() = runBlockingTest {
+        val reaction1 = randomReactionEntity(userId = "reactionUserId1")
+        val reaction2 = randomReactionEntity(userId = "reactionUserId2")
+        val message1 = randomMessageEntity(
+            id = "messageId1",
+            userId = "messageUserId1",
+            latestReactions = listOf(reaction1, reaction2)
+        )
+        val message2 = randomMessageEntity(id = "messageId2", userId = "messageUserId2")
+        When calling messages.selectEntities(listOf("messageId1", "messageId2")) doReturn listOf(message1, message2)
+        When calling users.selectUserMap(
+            listOf(
+                "reactionUserId1",
+                "reactionUserId2",
+                "messageUserId1",
+                "messageUserId2"
+            )
+        ) doReturn listOf(
+            randomUser(id = "reactionUserId1"),
+            randomUser(id = "reactionUserId2"),
+            randomUser(id = "messageUserId1"),
+            randomUser(id = "messageUserId2")
+        ).associateBy(User::id)
+
+        val result = sut.selectMessages(listOf("messageId1", "messageId2"))
 
         result.size shouldBeEqualTo 2
-        result.any { it.cid == "cid1" && it.messages.size == 1 && it.messages.first().id == "messageId1" } shouldBeEqualTo true
-        result.any { it.cid == "cid2" && it.messages.size == 1 && it.messages.first().id == "messageId2" } shouldBeEqualTo true
     }
 }


### PR DESCRIPTION
The batch event update system has become quite complex. This PR simplifies it which makes it:

- harder to make coding mistakes which forget to store users, or other required data
- easier to correctly handle events

While working on this I noticed the following issues with the existing code:

- If multiple events update a channel or messages, we sometimes ignored everything but the last update
- ReactionNewEvent and other reaction events didn't store reaction.user
- NotificationChannelDeletedEvent didn't set the user

Needs to be updated by Oleg to support the new repository structure